### PR TITLE
feat(filter): support combined kind and depth payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,53 @@ This may be useful later for advanced workflows, but the main MVP is based on **
 - Fold kinds within a specific parent kind
 - Build overview modes for large files
 
+## Keybinding payload examples
+
+Collapse second-level methods:
+
+```json
+{
+  "key": "ctrl+alt+m",
+  "command": "semanticFold.collapse",
+  "args": {
+    "filter": {
+      "kinds": ["method"],
+      "exactSymbolDepth": 2
+    }
+  }
+}
+```
+
+Collapse top-level classes and functions:
+
+```json
+{
+  "key": "ctrl+alt+o",
+  "command": "semanticFold.collapse",
+  "args": {
+    "filter": {
+      "kinds": ["class", "function"],
+      "exactSymbolDepth": 1
+    }
+  }
+}
+```
+
+Collapse implementation details below the top level:
+
+```json
+{
+  "key": "ctrl+alt+i",
+  "command": "semanticFold.collapse",
+  "args": {
+    "filter": {
+      "kinds": ["method", "function"],
+      "minSymbolDepth": 2
+    }
+  }
+}
+```
+
 ## MVP scope
 
 The first version focuses on the active editor and aims to support languages with decent document-symbol providers, such as:
@@ -260,10 +307,10 @@ Open the workspace in VS Code and launch the extension host from the debugger.
 
 ## Roadmap
 
-- [ ] Scaffold extension
-- [ ] Implement symbol collection
-- [ ] Normalize `DocumentSymbol` trees
-- [ ] Add filter engine
+- [x] Scaffold extension
+- [x] Implement symbol collection
+- [x] Normalize `DocumentSymbol` trees
+- [x] Add filter engine
 - [ ] Add targeted collapse execution
 - [ ] Add keybinding-ready generic command
 - [ ] Add convenience commands

--- a/src/engine/foldExecutor.ts
+++ b/src/engine/foldExecutor.ts
@@ -1,5 +1,6 @@
 import type { CollapseArgs } from "../model/filters";
 import type { RegionNode } from "../model/region";
+import { filterRegions } from "./filterEngine";
 
 export function isFoldableRegion(region: RegionNode): boolean {
 	return Number.isInteger(region.rangeStartLine)
@@ -17,11 +18,18 @@ export function collectFoldableRegions(rootNodes: readonly RegionNode[]): Region
 	return foldableRegions;
 }
 
+export function selectFoldableRegions(
+	args: CollapseArgs,
+	rootNodes: readonly RegionNode[]
+): RegionNode[] {
+	return filterRegions(rootNodes, args.filter).filter(isFoldableRegion);
+}
+
 export async function runFoldCommand(
-	_args: CollapseArgs,
+	args: CollapseArgs,
 	rootNodes: readonly RegionNode[] = []
 ): Promise<void> {
-	collectFoldableRegions(rootNodes);
+	selectFoldableRegions(args, rootNodes);
 }
 
 function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]): void {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { filterRegions, flattenRegions } from "../engine/filterEngine";
-import { collectFoldableRegions } from "../engine/foldExecutor";
+import { collectFoldableRegions, selectFoldableRegions } from "../engine/foldExecutor";
 import { getRegions } from "../engine/regionCollector";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
 import { mapSymbolKind } from "../util/symbolKindMap";
@@ -240,6 +240,25 @@ suite("Region Filtering", () => {
 			["inner"]
 		);
 	});
+
+	test("returns only regions satisfying every kind and depth constraint", () => {
+		const regions = createDepthFilterFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				exactSymbolDepth: 2,
+			}).map((region) => region.name),
+			["run", "stop"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				exactSymbolDepth: 1,
+			}).map((region) => region.name),
+			[]
+		);
+	});
 });
 
 suite("Fold Execution Guards", () => {
@@ -255,6 +274,22 @@ suite("Fold Execution Guards", () => {
 		assert.deepStrictEqual(
 			foldableRegions.map((region) => region.name),
 			["Example", "run"]
+		);
+	});
+
+	test("selects foldable regions using a combined command payload filter", () => {
+		const regions = createDepthFilterFixture();
+
+		const foldableRegions = selectFoldableRegions({
+			filter: {
+				kinds: ["method"],
+				exactSymbolDepth: 2,
+			},
+		}, regions);
+
+		assert.deepStrictEqual(
+			foldableRegions.map((region) => region.name),
+			["run", "stop"]
 		);
 	});
 });


### PR DESCRIPTION
- select foldable regions through command payload filters
- verify kind and symbol-depth constraints compose together
- cover combined command payload target selection
- document keybinding examples for common filter combinations

Closes #19