### PR TITLE
feat(fold): execute exact selection-line folds

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,12 @@ That means:
 - semantic token coverage may vary
 - comment/import folding may depend on folding providers
 
+### Flat symbol fallback
+
+Some language providers return flat `SymbolInformation` results instead of hierarchical `DocumentSymbol` trees. Semantic Fold treats those symbols as top-level regions so basic kind filtering, depth `1` filtering, and exact selection-line folding can still work.
+
+Flat fallback mode does not infer parent/child relationships. Parent, ancestor, and deeper symbol-depth filters require hierarchical provider data and may return no matches when only flat symbols are available.
+
 ## Design decisions
 
 ### Why not semantic tokens first?

--- a/src/engine/foldExecutor.ts
+++ b/src/engine/foldExecutor.ts
@@ -1,6 +1,14 @@
+import * as vscode from "vscode";
 import type { CollapseArgs } from "../model/filters";
 import type { RegionNode } from "../model/region";
 import { filterRegions } from "./filterEngine";
+
+type FoldCommand = "editor.fold" | "editor.unfold";
+
+export type FoldCommandExecutor = (
+	command: FoldCommand,
+	args: { selectionLines: number[] }
+) => Thenable<unknown>;
 
 export function isFoldableRegion(region: RegionNode): boolean {
 	return Number.isInteger(region.rangeStartLine)
@@ -25,11 +33,23 @@ export function selectFoldableRegions(
 	return filterRegions(rootNodes, args.filter).filter(isFoldableRegion);
 }
 
+export function collectSelectionLines(regions: readonly RegionNode[]): number[] {
+	return [...new Set(regions.map((region) => region.selectionLine))]
+		.sort((left, right) => left - right);
+}
+
 export async function runFoldCommand(
 	args: CollapseArgs,
-	rootNodes: readonly RegionNode[] = []
+	rootNodes: readonly RegionNode[] = [],
+	executeCommand: FoldCommandExecutor = defaultFoldCommandExecutor
 ): Promise<void> {
-	selectFoldableRegions(args, rootNodes);
+	const selectionLines = collectSelectionLines(selectFoldableRegions(args, rootNodes));
+
+	if(selectionLines.length === 0) {
+		return;
+	}
+
+	await executeCommand(getFoldCommand(args), { selectionLines });
 }
 
 function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]): void {
@@ -40,4 +60,19 @@ function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]
 	for(const child of region.children) {
 		collectFoldableRegion(child, foldableRegions);
 	}
+}
+
+function getFoldCommand(args: CollapseArgs): FoldCommand {
+	if(args.mode === "expand") {
+		return "editor.unfold";
+	}
+
+	return "editor.fold";
+}
+
+function defaultFoldCommandExecutor(
+	command: FoldCommand,
+	args: { selectionLines: number[] }
+): Thenable<unknown> {
+	return vscode.commands.executeCommand(command, args);
 }

--- a/src/engine/symbolNormaliser.ts
+++ b/src/engine/symbolNormaliser.ts
@@ -10,11 +10,21 @@ export function normalizeSymbols(
 	}
 
 	return symbols
-		.filter(isDocumentSymbol)
-		.map((symbol, index) => createRegionNode(symbol, undefined, 1, `${index}`));
+		.map((symbol, index) => {
+			if(isDocumentSymbol(symbol)) {
+				return symbolRegionNode(symbol, undefined, 1, `${index}`);
+			}
+
+			if(isSymbolInformation(symbol)) {
+				return symbolInformationRegionNode(symbol, index);
+			}
+
+			return undefined;
+		})
+		.filter((region): region is RegionNode => region !== undefined);
 }
 
-function createRegionNode(
+function symbolRegionNode(
 	symbol: vscode.DocumentSymbol,
 	parent: RegionNode | undefined,
 	symbolDepth: number,
@@ -36,9 +46,27 @@ function createRegionNode(
 
 	node.children = symbol.children
 		.filter(isDocumentSymbol)
-		.map((child, index) => createRegionNode(child, node, symbolDepth + 1, `${path}.${index}`));
+		.map((child, index) => symbolRegionNode(child, node, symbolDepth + 1, `${path}.${index}`));
 
 	return node;
+}
+
+function symbolInformationRegionNode(
+	symbol: vscode.SymbolInformation,
+	index: number
+): RegionNode {
+	return {
+		id: symbolInformationNodeId(symbol, `${index}`),
+		name: symbol.name,
+		kind: mapSymbolKind(symbol.kind),
+		rangeStartLine: symbol.location.range.start.line,
+		rangeEndLine: symbol.location.range.end.line,
+		selectionLine: symbol.location.range.start.line,
+		symbolDepth: 1,
+		children: [],
+		source: "symbolInformation",
+		symbolKind: symbol.kind,
+	};
 }
 
 function createNodeId(symbol: vscode.DocumentSymbol, path: string): string {
@@ -48,6 +76,18 @@ function createNodeId(symbol: vscode.DocumentSymbol, path: string): string {
 		symbol.range.start.line,
 		symbol.range.end.line,
 		symbol.selectionRange.start.line,
+		symbol.kind,
+		symbol.name,
+	].join(":");
+}
+
+function symbolInformationNodeId(symbol: vscode.SymbolInformation, path: string): string {
+	return [
+		"symbolInformation",
+		path,
+		symbol.location.uri.toString(),
+		symbol.location.range.start.line,
+		symbol.location.range.end.line,
 		symbol.kind,
 		symbol.name,
 	].join(":");
@@ -64,16 +104,29 @@ function isDocumentSymbol(value: unknown): value is vscode.DocumentSymbol {
 		&& symbol.range.end.line >= symbol.range.start.line;
 }
 
+function isSymbolInformation(value: unknown): value is vscode.SymbolInformation {
+	const symbol = value as Partial<vscode.SymbolInformation>;
+	const location = symbol.location as Partial<vscode.Location> | undefined;
+
+	return typeof symbol.name === "string"
+		&& typeof symbol.kind === "number"
+		&& location !== undefined
+		&& location.uri instanceof vscode.Uri
+		&& isRange(location.range)
+		&& location.range.end.line >= location.range.start.line;
+}
+
 function isRange(value: unknown): value is vscode.Range {
 	const range = value as Partial<vscode.Range>;
 
-	return isPosition(range.start) && isPosition(range.end);
+	return range !== undefined && isPosition(range.start) && isPosition(range.end);
 }
 
 function isPosition(value: unknown): value is vscode.Position {
 	const position = value as Partial<vscode.Position>;
 
-	return typeof position.line === "number"
+	return position !== undefined
+		&& typeof position.line === "number"
 		&& Number.isInteger(position.line)
 		&& position.line >= 0
 		&& typeof position.character === "number"

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,12 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { filterRegions, flattenRegions } from "../engine/filterEngine";
-import { collectFoldableRegions, selectFoldableRegions } from "../engine/foldExecutor";
+import {
+	collectFoldableRegions,
+	collectSelectionLines,
+	runFoldCommand,
+	selectFoldableRegions,
+} from "../engine/foldExecutor";
 import { getRegions } from "../engine/regionCollector";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
 import { mapSymbolKind } from "../util/symbolKindMap";
@@ -292,6 +297,58 @@ suite("Fold Execution Guards", () => {
 			["run", "stop"]
 		);
 	});
+
+	test("collects deduplicated sorted selection lines from filtered nodes", () => {
+		const regions = createDuplicateSelectionFixture();
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({}, regions)),
+			[2, 6, 12]
+		);
+	});
+
+	test("executes exact non-recursive fold selection lines", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+
+		await runFoldCommand({}, regions, async (command, args) => {
+			executedCommands.push({ command, selectionLines: args.selectionLines });
+		});
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.fold",
+			selectionLines: [2, 6, 12],
+		}]);
+	});
+
+	test("does not execute a fold command when no filtered nodes are foldable", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+
+		await runFoldCommand({
+			filter: {
+				kinds: ["property"],
+			},
+		}, regions, async (command, args) => {
+			executedCommands.push({ command, selectionLines: args.selectionLines });
+		});
+
+		assert.deepStrictEqual(executedCommands, []);
+	});
+
+	test("executes exact unfold selection lines for expand mode", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+
+		await runFoldCommand({ mode: "expand" }, regions, async (command, args) => {
+			executedCommands.push({ command, selectionLines: args.selectionLines });
+		});
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.unfold",
+			selectionLines: [2, 6, 12],
+		}]);
+	});
 });
 
 function createSymbol(
@@ -334,6 +391,27 @@ function createDepthFilterFixture(): ReturnType<typeof normalizeSymbols> {
 	classSymbol.children.push(methodSymbol, siblingMethodSymbol);
 
 	return normalizeSymbols([classSymbol, functionSymbol]);
+}
+
+function createDuplicateSelectionFixture(): ReturnType<typeof normalizeSymbols> {
+	const firstMethodSymbol = createSymbol("first", vscode.SymbolKind.Method, 6, 10);
+	const duplicateLineMethodSymbol = createSymbol("second", vscode.SymbolKind.Method, 6, 9);
+	const earlierMethodSymbol = createSymbol("earlier", vscode.SymbolKind.Method, 2, 4);
+	const laterMethodSymbol = createSymbol("later", vscode.SymbolKind.Method, 12, 16);
+	const propertySymbol = createSymbol("name", vscode.SymbolKind.Property, 18, 18);
+
+	return normalizeSymbols([
+		firstMethodSymbol,
+		duplicateLineMethodSymbol,
+		earlierMethodSymbol,
+		laterMethodSymbol,
+		propertySymbol,
+	]);
+}
+
+interface ExecutedCommand {
+	command: "editor.fold" | "editor.unfold";
+	selectionLines: number[];
 }
 
 async function activateExtension(): Promise<void> {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -54,6 +54,28 @@ suite("Document Symbol Collection", () => {
 
 		assert.deepStrictEqual(regions, []);
 	});
+
+	test("accepts flat symbol information provider results", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "function helper() {\n\treturn true;\n}\n",
+			language: "typescript",
+		});
+		const helperSymbol = createSymbolInformation(
+			"helper",
+			vscode.SymbolKind.Function,
+			document.uri,
+			0,
+			2
+		);
+
+		const regions = await getRegions(document, async () => {
+			return [helperSymbol];
+		});
+
+		assert.strictEqual(regions.length, 1);
+		assert.strictEqual(regions[0].name, "helper");
+		assert.strictEqual(regions[0].source, "symbolInformation");
+	});
 });
 
 suite("Document Symbol Normalisation", () => {
@@ -90,6 +112,33 @@ suite("Document Symbol Normalisation", () => {
 			normalizeSymbols([{ name: "broken" } as unknown as vscode.DocumentSymbol]),
 			[]
 		);
+	});
+
+	test("normalizes flat symbol information into top-level fallback nodes", () => {
+		const uri = vscode.Uri.parse("file:///workspace/example.ts");
+		const symbols = [
+			createSymbolInformation("Example", vscode.SymbolKind.Class, uri, 0, 10),
+			createSymbolInformation("run", vscode.SymbolKind.Method, uri, 2, 5),
+			createSymbolInformation("helper", vscode.SymbolKind.Function, uri, 12, 14),
+		];
+
+		const regions = normalizeSymbols(symbols);
+
+		assert.deepStrictEqual(
+			regions.map((region) => region.name),
+			["Example", "run", "helper"]
+		);
+		assert.deepStrictEqual(
+			regions.map((region) => region.kind),
+			["class", "method", "function"]
+		);
+		assert.deepStrictEqual(
+			regions.map((region) => region.symbolDepth),
+			[1, 1, 1]
+		);
+		assert.ok(regions.every((region) => region.parent === undefined));
+		assert.ok(regions.every((region) => region.children.length === 0));
+		assert.ok(regions.every((region) => region.source === "symbolInformation"));
 	});
 });
 
@@ -264,6 +313,22 @@ suite("Region Filtering", () => {
 			[]
 		);
 	});
+
+	test("keeps kind and depth filters useful for flat fallback symbols", () => {
+		const regions = createFlatFallbackFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				exactSymbolDepth: 1,
+			}).map((region) => region.name),
+			["run", "stop"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, { exactSymbolDepth: 2 }).map((region) => region.name),
+			[]
+		);
+	});
 });
 
 suite("Fold Execution Guards", () => {
@@ -349,6 +414,22 @@ suite("Fold Execution Guards", () => {
 			selectionLines: [2, 6, 12],
 		}]);
 	});
+
+	test("selects foldable regions from flat fallback symbols", () => {
+		const regions = createFlatFallbackFixture();
+
+		const foldableRegions = selectFoldableRegions({
+			filter: {
+				kinds: ["method"],
+				exactSymbolDepth: 1,
+			},
+		}, regions);
+
+		assert.deepStrictEqual(
+			foldableRegions.map((region) => region.name),
+			["run", "stop"]
+		);
+	});
 });
 
 function createSymbol(
@@ -363,6 +444,21 @@ function createSymbol(
 		kind,
 		new vscode.Range(startLine, 0, endLine, 1),
 		new vscode.Range(startLine, 0, startLine, 1)
+	);
+}
+
+function createSymbolInformation(
+	name: string,
+	kind: vscode.SymbolKind,
+	uri: vscode.Uri,
+	startLine: number,
+	endLine: number
+): vscode.SymbolInformation {
+	return new vscode.SymbolInformation(
+		name,
+		kind,
+		"",
+		new vscode.Location(uri, new vscode.Range(startLine, 0, endLine, 1))
 	);
 }
 
@@ -391,6 +487,17 @@ function createDepthFilterFixture(): ReturnType<typeof normalizeSymbols> {
 	classSymbol.children.push(methodSymbol, siblingMethodSymbol);
 
 	return normalizeSymbols([classSymbol, functionSymbol]);
+}
+
+function createFlatFallbackFixture(): ReturnType<typeof normalizeSymbols> {
+	const uri = vscode.Uri.parse("file:///workspace/flat.ts");
+
+	return normalizeSymbols([
+		createSymbolInformation("Example", vscode.SymbolKind.Class, uri, 0, 18),
+		createSymbolInformation("run", vscode.SymbolKind.Method, uri, 1, 10),
+		createSymbolInformation("stop", vscode.SymbolKind.Method, uri, 11, 16),
+		createSymbolInformation("name", vscode.SymbolKind.Property, uri, 18, 18),
+	]);
 }
 
 function createDuplicateSelectionFixture(): ReturnType<typeof normalizeSymbols> {


### PR DESCRIPTION
- collect selection lines from filtered foldable regions
- deduplicate and sort target lines before execution
- dispatch editor.fold without recursive fold levels
- cover exact fold and unfold command payloads

- normalize SymbolInformation results into top-level region nodes
- keep kind and depth filtering usable without hierarchy
- guard symbol shape checks for weak provider output
- document flat fallback limitations


Closes #20
Closes #16
Closes #3
Closes #2