### PR TITLE
feat(commands): normalize generic collapse payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,23 @@ This may be useful later for advanced workflows, but the main MVP is based on **
 
 ## Keybinding payload examples
 
+The generic `semanticFold.collapse` command accepts one optional `args` object:
+
+```json
+{
+  "filter": {
+    "kinds": ["method"],
+    "excludeKinds": ["unknown"],
+    "exactSymbolDepth": 2,
+    "minSymbolDepth": 1,
+    "maxSymbolDepth": 3
+  },
+  "preserveCursorContext": true
+}
+```
+
+Invalid or incomplete fields are ignored. For example, unknown kind strings, non-integer depths, malformed `nameRegex` values, and non-object payloads fall back to the safest valid subset instead of failing the command.
+
 Collapse second-level methods:
 
 ```json

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -1,9 +1,9 @@
 import * as vscode from "vscode";
 import { getRegions } from "../engine/regionCollector";
 import { runFoldCommand } from "../engine/foldExecutor";
-import type { CollapseArgs } from "../model/filters";
+import { normaliseArgs } from "../model/filters";
 
-export async function collapseCommand(args: CollapseArgs = {}): Promise<void> {
+export async function collapseCommand(args?: unknown): Promise<void> {
 	const editor = vscode.window.activeTextEditor;
 
 	if(!editor) {
@@ -12,5 +12,5 @@ export async function collapseCommand(args: CollapseArgs = {}): Promise<void> {
 
 	const regions = await getRegions(editor.document);
 
-	await runFoldCommand({ ...args, mode: "collapse" }, regions);
+	await runFoldCommand(normaliseArgs(args, "collapse"), regions);
 }

--- a/src/commands/expand.ts
+++ b/src/commands/expand.ts
@@ -1,9 +1,9 @@
 import * as vscode from "vscode";
 import { getRegions } from "../engine/regionCollector";
 import { runFoldCommand } from "../engine/foldExecutor";
-import type { CollapseArgs } from "../model/filters";
+import { normaliseArgs } from "../model/filters";
 
-export async function expandCommand(args: CollapseArgs = {}): Promise<void> {
+export async function expandCommand(args?: unknown): Promise<void> {
 	const editor = vscode.window.activeTextEditor;
 
 	if(!editor) {
@@ -12,5 +12,5 @@ export async function expandCommand(args: CollapseArgs = {}): Promise<void> {
 
 	const regions = await getRegions(editor.document);
 
-	await runFoldCommand({ ...args, mode: "expand" }, regions);
+	await runFoldCommand(normaliseArgs(args, "expand"), regions);
 }

--- a/src/model/filters.ts
+++ b/src/model/filters.ts
@@ -1,4 +1,4 @@
-import type { RegionKind } from "./region";
+import { REGION_KINDS, type RegionKind } from "./region";
 
 export interface CollapseFilter {
 	kinds?: RegionKind[];
@@ -22,4 +22,116 @@ export interface CollapseArgs {
 	filter?: CollapseFilter;
 	mode?: "collapse" | "expand" | "toggle";
 	preserveCursorContext?: boolean;
+}
+
+type DepthFilterKey =
+	| "exactSymbolDepth"
+	| "minSymbolDepth"
+	| "maxSymbolDepth"
+	| "exactFoldDepth"
+	| "minFoldDepth"
+	| "maxFoldDepth";
+
+type KindFilterKey = "kinds" | "excludeKinds" | "parentKinds" | "ancestorKinds";
+
+const depthFilterKeys: DepthFilterKey[] = [
+	"exactSymbolDepth",
+	"minSymbolDepth",
+	"maxSymbolDepth",
+	"exactFoldDepth",
+	"minFoldDepth",
+	"maxFoldDepth",
+];
+
+const kindFilterKeys: KindFilterKey[] = [
+	"kinds",
+	"excludeKinds",
+	"parentKinds",
+	"ancestorKinds",
+];
+
+const regionKinds = new Set<string>(REGION_KINDS);
+
+export function normaliseArgs(args: unknown, mode: CollapseArgs["mode"] = "collapse"): CollapseArgs {
+	const payload = isRecord(args) ? args : {};
+	const normalisedArgs: CollapseArgs = { mode };
+	const filter = normaliseCollapseFilter(payload.filter);
+
+	if(filter !== undefined) {
+		normalisedArgs.filter = filter;
+	}
+
+	if(typeof payload.preserveCursorContext === "boolean") {
+		normalisedArgs.preserveCursorContext = payload.preserveCursorContext;
+	}
+
+	return normalisedArgs;
+}
+
+export function normaliseCollapseFilter(filter: unknown): CollapseFilter | undefined {
+	if(!isRecord(filter)) {
+		return undefined;
+	}
+
+	const normalisedFilter: CollapseFilter = {};
+
+	for(const key of kindFilterKeys) {
+		const kinds = normaliseRegionKinds(filter[key]);
+
+		if(kinds.length > 0) {
+			normalisedFilter[key] = kinds;
+		}
+	}
+
+	for(const key of depthFilterKeys) {
+		const depth = normaliseDepth(filter[key]);
+
+		if(depth !== undefined) {
+			normalisedFilter[key] = depth;
+		}
+	}
+
+	if(typeof filter.nameRegex === "string" && isValidRegex(filter.nameRegex)) {
+		normalisedFilter.nameRegex = filter.nameRegex;
+	}
+
+	if(Object.keys(normalisedFilter).length === 0) {
+		return undefined;
+	}
+
+	return normalisedFilter;
+}
+
+function normaliseRegionKinds(value: unknown): RegionKind[] {
+	if(!Array.isArray(value)) {
+		return [];
+	}
+
+	return [...new Set(value)].filter(isRegionKind);
+}
+
+function normaliseDepth(value: unknown): number | undefined {
+	if(typeof value !== "number" || !Number.isInteger(value) || value < 1) {
+		return undefined;
+	}
+
+	return value;
+}
+
+function isRegionKind(value: unknown): value is RegionKind {
+	return typeof value === "string" && regionKinds.has(value);
+}
+
+function isValidRegex(value: string): boolean {
+	try {
+		new RegExp(value);
+
+		return true;
+	} catch {
+		return false;
+	}
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
 }

--- a/src/model/region.ts
+++ b/src/model/region.ts
@@ -1,18 +1,21 @@
-export type RegionKind =
-	| "class"
-	| "interface"
-	| "enum"
-	| "namespace"
-	| "function"
-	| "method"
-	| "constructor"
-	| "property"
-	| "field"
-	| "variable"
-	| "import"
-	| "comment"
-	| "region"
-	| "unknown";
+export const REGION_KINDS = [
+	"class",
+	"interface",
+	"enum",
+	"namespace",
+	"function",
+	"method",
+	"constructor",
+	"property",
+	"field",
+	"variable",
+	"import",
+	"comment",
+	"region",
+	"unknown",
+] as const;
+
+export type RegionKind = typeof REGION_KINDS[number];
 
 export interface RegionNode {
 	id: string;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -9,6 +9,7 @@ import {
 } from "../engine/foldExecutor";
 import { getRegions } from "../engine/regionCollector";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
+import { normaliseArgs, normaliseCollapseFilter } from "../model/filters";
 import { mapSymbolKind } from "../util/symbolKindMap";
 
 suite("Semantic Fold Foundation", () => {
@@ -114,7 +115,7 @@ suite("Document Symbol Normalisation", () => {
 		);
 	});
 
-	test("normalizes flat symbol information into top-level fallback nodes", () => {
+	test("normalises flat symbol information into top-level fallback nodes", () => {
 		const uri = vscode.Uri.parse("file:///workspace/example.ts");
 		const symbols = [
 			createSymbolInformation("Example", vscode.SymbolKind.Class, uri, 0, 10),
@@ -173,6 +174,90 @@ suite("Symbol Kind Mapping", () => {
 
 	test("falls back safely for unmapped symbol kinds", () => {
 		assert.strictEqual(mapSymbolKind(999 as vscode.SymbolKind), "unknown");
+	});
+});
+
+suite("Command Argument Normalisation", () => {
+	test("accepts structured keybinding payload filters", () => {
+		assert.deepStrictEqual(
+			normaliseArgs({
+				filter: {
+					kinds: ["method", "function"],
+					excludeKinds: ["unknown"],
+					exactSymbolDepth: 2,
+					minSymbolDepth: 1,
+					nameRegex: "^handle",
+				},
+				preserveCursorContext: true,
+			}, "collapse"),
+			{
+				filter: {
+					kinds: ["method", "function"],
+					excludeKinds: ["unknown"],
+					exactSymbolDepth: 2,
+					minSymbolDepth: 1,
+					nameRegex: "^handle",
+				},
+				mode: "collapse",
+				preserveCursorContext: true,
+			}
+		);
+	});
+
+	test("deduplicates valid region kinds and ignores invalid kind values", () => {
+		assert.deepStrictEqual(
+			normaliseCollapseFilter({
+				kinds: ["method", "method", "not-a-kind", 42],
+				excludeKinds: ["property", "also-bad"],
+			}),
+			{
+				kinds: ["method"],
+				excludeKinds: ["property"],
+			}
+		);
+	});
+
+	test("ignores invalid or incomplete payload fields without throwing", () => {
+		assert.deepStrictEqual(normaliseArgs(undefined, "collapse"), {
+			mode: "collapse",
+		});
+		assert.deepStrictEqual(normaliseArgs("bad", "collapse"), {
+			mode: "collapse",
+		});
+		assert.deepStrictEqual(
+			normaliseArgs({
+				filter: {
+					kinds: "method",
+					exactSymbolDepth: 0,
+					minSymbolDepth: 2.5,
+					maxSymbolDepth: "3",
+					nameRegex: "[",
+				},
+			}, "collapse"),
+			{
+				mode: "collapse",
+			}
+		);
+	});
+
+	test("uses the command mode requested by the command implementation", () => {
+		assert.deepStrictEqual(
+			normaliseArgs({
+				mode: "expand",
+				filter: {
+					kinds: ["method"],
+				},
+			}, "collapse"),
+			{
+				filter: {
+					kinds: ["method"],
+				},
+				mode: "collapse",
+			}
+		);
+		assert.deepStrictEqual(normaliseArgs({}, "expand"), {
+			mode: "expand",
+		});
 	});
 });
 


### PR DESCRIPTION
- define runtime command argument normalization
- validate region kinds and depth filters defensively
- wire collapse and expand commands through normalized args
- document keybinding payload shape and soft-fail behavior
- cover valid and invalid command payloads

Closes #21