### PR TITLE
fix(fold): toggle keybinding payloads by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,9 @@ The generic `semanticFold.collapse` command accepts one optional `args` object:
 
 Invalid or incomplete fields are ignored. For example, unknown kind strings, non-integer depths, malformed `nameRegex` values, and non-object payloads fall back to the safest valid subset instead of failing the command.
 
-Collapse second-level methods:
+Keybinding payloads default to toggle mode: pressing the same binding again unfolds the same matching regions. Set `"mode": "collapse"`, `"mode": "expand"`, or `"mode": "toggle"` in the payload to force a specific action.
+
+Toggle second-level methods:
 
 ```json
 {
@@ -145,7 +147,7 @@ Collapse second-level methods:
 }
 ```
 
-Collapse top-level classes and functions:
+Toggle top-level classes and functions:
 
 ```json
 {
@@ -160,7 +162,7 @@ Collapse top-level classes and functions:
 }
 ```
 
-Collapse implementation details below the top level:
+Toggle implementation details below the top level:
 
 ```json
 {

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -1,7 +1,7 @@
 import * as vscode from "vscode";
 import { getRegions } from "../engine/regionCollector";
 import { runFoldCommand } from "../engine/foldExecutor";
-import { normaliseArgs } from "../model/filters";
+import { type CollapseArgs, normaliseArgs } from "../model/filters";
 
 export async function collapseCommand(args?: unknown): Promise<void> {
 	const editor = vscode.window.activeTextEditor;
@@ -12,5 +12,17 @@ export async function collapseCommand(args?: unknown): Promise<void> {
 
 	const regions = await getRegions(editor.document);
 
-	await runFoldCommand(normaliseArgs(args, "collapse"), regions);
+	await runFoldCommand(normaliseArgs(args, getDefaultCollapseMode(args)), regions);
+}
+
+export function getDefaultCollapseMode(args: unknown): CollapseArgs["mode"] {
+	if(isRecord(args)) {
+		return "toggle";
+	}
+
+	return "collapse";
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+	return typeof value === "object" && value !== null;
 }

--- a/src/engine/foldExecutor.ts
+++ b/src/engine/foldExecutor.ts
@@ -3,7 +3,7 @@ import type { CollapseArgs } from "../model/filters";
 import type { RegionNode } from "../model/region";
 import { filterRegions } from "./filterEngine";
 
-type FoldCommand = "editor.fold" | "editor.unfold";
+type FoldCommand = "editor.fold" | "editor.unfold" | "editor.toggleFold";
 
 export type FoldCommandExecutor = (
 	command: FoldCommand,
@@ -67,6 +67,10 @@ function getFoldCommand(args: CollapseArgs): FoldCommand {
 		return "editor.unfold";
 	}
 
+	if(args.mode === "toggle") {
+		return "editor.toggleFold";
+	}
+
 	return "editor.fold";
 }
 
@@ -74,5 +78,29 @@ function defaultFoldCommandExecutor(
 	command: FoldCommand,
 	args: { selectionLines: number[] }
 ): Thenable<unknown> {
+	if(command === "editor.toggleFold") {
+		return executeToggleFold(args.selectionLines);
+	}
+
 	return vscode.commands.executeCommand(command, args);
+}
+
+async function executeToggleFold(selectionLines: readonly number[]): Promise<unknown> {
+	const editor = vscode.window.activeTextEditor;
+
+	if(!editor) {
+		return undefined;
+	}
+
+	const previousSelections = editor.selections;
+
+	editor.selections = selectionLines.map((line) => {
+		return new vscode.Selection(line, 0, line, 0);
+	});
+
+	try {
+		return await vscode.commands.executeCommand("editor.toggleFold");
+	} finally {
+		editor.selections = previousSelections;
+	}
 }

--- a/src/model/filters.ts
+++ b/src/model/filters.ts
@@ -33,6 +33,7 @@ type DepthFilterKey =
 	| "maxFoldDepth";
 
 type KindFilterKey = "kinds" | "excludeKinds" | "parentKinds" | "ancestorKinds";
+type CommandMode = NonNullable<CollapseArgs["mode"]>;
 
 const depthFilterKeys: DepthFilterKey[] = [
 	"exactSymbolDepth",
@@ -54,7 +55,7 @@ const regionKinds = new Set<string>(REGION_KINDS);
 
 export function normaliseArgs(args: unknown, mode: CollapseArgs["mode"] = "collapse"): CollapseArgs {
 	const payload = isRecord(args) ? args : {};
-	const normalisedArgs: CollapseArgs = { mode };
+	const normalisedArgs: CollapseArgs = { mode: normaliseMode(payload.mode) ?? mode };
 	const filter = normaliseCollapseFilter(payload.filter);
 
 	if(filter !== undefined) {
@@ -66,6 +67,14 @@ export function normaliseArgs(args: unknown, mode: CollapseArgs["mode"] = "colla
 	}
 
 	return normalisedArgs;
+}
+
+function normaliseMode(value: unknown): CommandMode | undefined {
+	if(value === "collapse" || value === "expand" || value === "toggle") {
+		return value;
+	}
+
+	return undefined;
 }
 
 export function normaliseCollapseFilter(filter: unknown): CollapseFilter | undefined {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,5 +1,6 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
+import { getDefaultCollapseMode } from "../commands/collapse";
 import { filterRegions, flattenRegions } from "../engine/filterEngine";
 import {
 	collectFoldableRegions,
@@ -240,7 +241,7 @@ suite("Command Argument Normalisation", () => {
 		);
 	});
 
-	test("uses the command mode requested by the command implementation", () => {
+	test("uses explicit command payload modes when provided", () => {
 		assert.deepStrictEqual(
 			normaliseArgs({
 				mode: "expand",
@@ -252,12 +253,31 @@ suite("Command Argument Normalisation", () => {
 				filter: {
 					kinds: ["method"],
 				},
-				mode: "collapse",
+				mode: "expand",
 			}
 		);
+		assert.deepStrictEqual(normaliseArgs({ mode: "toggle" }, "collapse"), {
+			mode: "toggle",
+		});
+		assert.deepStrictEqual(normaliseArgs({ mode: "collapse" }, "toggle"), {
+			mode: "collapse",
+		});
+		assert.deepStrictEqual(normaliseArgs({ mode: "bad" }, "collapse"), {
+			mode: "collapse",
+		});
 		assert.deepStrictEqual(normaliseArgs({}, "expand"), {
 			mode: "expand",
 		});
+	});
+
+	test("defaults collapse keybinding payloads to toggle mode", () => {
+		assert.strictEqual(getDefaultCollapseMode(undefined), "collapse");
+		assert.strictEqual(getDefaultCollapseMode({}), "toggle");
+		assert.strictEqual(getDefaultCollapseMode({
+			filter: {
+				kinds: ["method"],
+			},
+		}), "toggle");
 	});
 });
 
@@ -471,7 +491,21 @@ suite("Fold Execution Guards", () => {
 		}]);
 	});
 
-	test("does not execute a fold command when no filtered nodes are foldable", async () => {
+	test("executes exact toggle selection lines for toggle mode", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+
+		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+			executedCommands.push({ command, selectionLines: args.selectionLines });
+		});
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.toggleFold",
+			selectionLines: [2, 6, 12],
+		}]);
+	});
+
+	test("does not execute any command when no filtered nodes are foldable", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
 
@@ -602,7 +636,7 @@ function createDuplicateSelectionFixture(): ReturnType<typeof normalizeSymbols> 
 }
 
 interface ExecutedCommand {
-	command: "editor.fold" | "editor.unfold";
+	command: "editor.fold" | "editor.unfold" | "editor.toggleFold";
 	selectionLines: number[];
 }
 


### PR DESCRIPTION
- default collapse command payloads to toggle mode
- honour explicit payload modes for collapse, expand, and toggle
- route semantic toggle through exact target selections
- document keybinding toggle behaviour

Closes #53