### PR TITLE
chore: update docs and version for phase 1 

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,14 +123,17 @@ The generic `semanticFold.collapse` command accepts one optional `args` object:
     "exactSymbolDepth": 2,
     "minSymbolDepth": 1,
     "maxSymbolDepth": 3
-  },
-  "preserveCursorContext": true
+  }
 }
 ```
 
 Invalid or incomplete fields are ignored. For example, unknown kind strings, non-integer depths, malformed `nameRegex` values, and non-object payloads fall back to the safest valid subset instead of failing the command.
 
-Keybinding payloads default to toggle mode: pressing the same binding again unfolds the same matching regions. Set `"mode": "collapse"`, `"mode": "expand"`, or `"mode": "toggle"` in the payload to force a specific action.
+Keybinding payloads default to toggle mode. If any matching target is expanded, pressing the binding collapses every matching target; when all matching targets are collapsed, pressing it expands them together. Set `"mode": "collapse"`, `"mode": "expand"`, or `"mode": "toggle"` in the payload to force a specific action.
+
+The `preserveCursorContext` field is accepted for payload compatibility, but Phase 1 folding does not protect the focused region from being folded. If the cursor is inside a folded target, VS Code moves the selection to visible fold context instead of reopening that method.
+
+Toggle state is tracked for folds created through Semantic Fold commands. Manual folding, unfolding, or other extensions can make the tracked state incomplete, but the next semantic toggle collapses a mixed target set back into a consistent state before later toggles expand it as a group.
 
 Toggle second-level methods:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semantic-fold",
-  "version": "0.0.1-dev",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semantic-fold",
-      "version": "0.0.1-dev",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "semantic-fold",
   "displayName": "Semantic Fold",
   "description": "Policy-driven code folding for VS Code",
-  "version": "0.0.1-dev",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.111.0"
   },

--- a/src/engine/foldExecutor.ts
+++ b/src/engine/foldExecutor.ts
@@ -3,12 +3,69 @@ import type { CollapseArgs } from "../model/filters";
 import type { RegionNode } from "../model/region";
 import { filterRegions } from "./filterEngine";
 
-type FoldCommand = "editor.fold" | "editor.unfold" | "editor.toggleFold";
+type FoldCommand = "editor.fold" | "editor.unfold";
+
+interface FoldCommandArgs {
+	selectionLines: number[];
+	levels: number;
+}
 
 export type FoldCommandExecutor = (
 	command: FoldCommand,
-	args: { selectionLines: number[] }
+	args: FoldCommandArgs
 ) => Thenable<unknown>;
+
+export class TrackedFoldState {
+	private readonly collapsedLinesByDocument = new Map<string, Set<number>>();
+
+	public areAllCollapsed(documentKey: string, selectionLines: readonly number[]): boolean {
+		const collapsedLines = this.collapsedLinesByDocument.get(documentKey);
+
+		if(!collapsedLines || selectionLines.length === 0) {
+			return false;
+		}
+
+		return selectionLines.every((line) => collapsedLines.has(line));
+	}
+
+	public markCollapsed(documentKey: string, selectionLines: readonly number[]): void {
+		const collapsedLines = this.getCollapsedLines(documentKey);
+
+		for(const line of selectionLines) {
+			collapsedLines.add(line);
+		}
+	}
+
+	public markExpanded(documentKey: string, selectionLines: readonly number[]): void {
+		const collapsedLines = this.collapsedLinesByDocument.get(documentKey);
+
+		if(!collapsedLines) {
+			return;
+		}
+
+		for(const line of selectionLines) {
+			collapsedLines.delete(line);
+		}
+
+		if(collapsedLines.size === 0) {
+			this.collapsedLinesByDocument.delete(documentKey);
+		}
+	}
+
+	private getCollapsedLines(documentKey: string): Set<number> {
+		const existingLines = this.collapsedLinesByDocument.get(documentKey);
+
+		if(existingLines) {
+			return existingLines;
+		}
+
+		const collapsedLines = new Set<number>();
+
+		this.collapsedLinesByDocument.set(documentKey, collapsedLines);
+
+		return collapsedLines;
+	}
+}
 
 export function isFoldableRegion(region: RegionNode): boolean {
 	return Number.isInteger(region.rangeStartLine)
@@ -41,7 +98,9 @@ export function collectSelectionLines(regions: readonly RegionNode[]): number[] 
 export async function runFoldCommand(
 	args: CollapseArgs,
 	rootNodes: readonly RegionNode[] = [],
-	executeCommand: FoldCommandExecutor = defaultFoldCommandExecutor
+	executeCommand: FoldCommandExecutor = defaultFoldCommandExecutor,
+	foldState: TrackedFoldState = defaultFoldState,
+	documentKey: string = getActiveDocumentKey()
 ): Promise<void> {
 	const selectionLines = collectSelectionLines(selectFoldableRegions(args, rootNodes));
 
@@ -49,7 +108,10 @@ export async function runFoldCommand(
 		return;
 	}
 
-	await executeCommand(getFoldCommand(args), { selectionLines });
+	const command = getFoldCommand(args, selectionLines, foldState, documentKey);
+
+	await executeCommand(command, { selectionLines, levels: 1 });
+	updateTrackedFoldState(command, selectionLines, foldState, documentKey);
 }
 
 function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]): void {
@@ -62,13 +124,22 @@ function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]
 	}
 }
 
-function getFoldCommand(args: CollapseArgs): FoldCommand {
+function getFoldCommand(
+	args: CollapseArgs,
+	selectionLines: readonly number[],
+	foldState: TrackedFoldState,
+	documentKey: string
+): FoldCommand {
 	if(args.mode === "expand") {
 		return "editor.unfold";
 	}
 
 	if(args.mode === "toggle") {
-		return "editor.toggleFold";
+		if(foldState.areAllCollapsed(documentKey, selectionLines)) {
+			return "editor.unfold";
+		}
+
+		return "editor.fold";
 	}
 
 	return "editor.fold";
@@ -76,31 +147,34 @@ function getFoldCommand(args: CollapseArgs): FoldCommand {
 
 function defaultFoldCommandExecutor(
 	command: FoldCommand,
-	args: { selectionLines: number[] }
+	args: FoldCommandArgs
 ): Thenable<unknown> {
-	if(command === "editor.toggleFold") {
-		return executeToggleFold(args.selectionLines);
-	}
-
 	return vscode.commands.executeCommand(command, args);
 }
 
-async function executeToggleFold(selectionLines: readonly number[]): Promise<unknown> {
+function updateTrackedFoldState(
+	command: FoldCommand,
+	selectionLines: readonly number[],
+	foldState: TrackedFoldState,
+	documentKey: string
+): void {
+	if(command === "editor.fold") {
+		foldState.markCollapsed(documentKey, selectionLines);
+
+		return;
+	}
+
+	foldState.markExpanded(documentKey, selectionLines);
+}
+
+function getActiveDocumentKey(): string {
 	const editor = vscode.window.activeTextEditor;
 
 	if(!editor) {
-		return undefined;
+		return "";
 	}
 
-	const previousSelections = editor.selections;
-
-	editor.selections = selectionLines.map((line) => {
-		return new vscode.Selection(line, 0, line, 0);
-	});
-
-	try {
-		return await vscode.commands.executeCommand("editor.toggleFold");
-	} finally {
-		editor.selections = previousSelections;
-	}
+	return editor.document.uri.toString();
 }
+
+const defaultFoldState = new TrackedFoldState();

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -7,6 +7,7 @@ import {
 	collectSelectionLines,
 	runFoldCommand,
 	selectFoldableRegions,
+	TrackedFoldState,
 } from "../engine/foldExecutor";
 import { getRegions } from "../engine/regionCollector";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
@@ -545,27 +546,83 @@ suite("Fold Execution Guards", () => {
 	test("executes exact non-recursive fold selection lines", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
 
 		await runFoldCommand({}, regions, async (command, args) => {
-			executedCommands.push({ command, selectionLines: args.selectionLines });
-		});
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://fold");
 
 		assert.deepStrictEqual(executedCommands, [{
 			command: "editor.fold",
+			levels: 1,
 			selectionLines: [2, 6, 12],
 		}]);
 	});
 
-	test("executes exact toggle selection lines for toggle mode", async () => {
+	test("collapses every toggle target when any target is expanded", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
 
 		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
-			executedCommands.push({ command, selectionLines: args.selectionLines });
-		});
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-collapse");
 
 		assert.deepStrictEqual(executedCommands, [{
-			command: "editor.toggleFold",
+			command: "editor.fold",
+			levels: 1,
+			selectionLines: [2, 6, 12],
+		}]);
+	});
+
+	test("expands every toggle target when all targets are collapsed", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		foldState.markCollapsed("test://toggle-expand", [2, 6, 12]);
+
+		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-expand");
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.unfold",
+			levels: 1,
+			selectionLines: [2, 6, 12],
+		}]);
+	});
+
+	test("collapses every toggle target when tracked target state is mixed", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		foldState.markCollapsed("test://toggle-mixed", [2]);
+
+		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-mixed");
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.fold",
+			levels: 1,
 			selectionLines: [2, 6, 12],
 		}]);
 	});
@@ -573,14 +630,19 @@ suite("Fold Execution Guards", () => {
 	test("does not execute any command when no filtered nodes are foldable", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
 
 		await runFoldCommand({
 			filter: {
 				kinds: ["property"],
 			},
 		}, regions, async (command, args) => {
-			executedCommands.push({ command, selectionLines: args.selectionLines });
-		});
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://empty");
 
 		assert.deepStrictEqual(executedCommands, []);
 	});
@@ -588,13 +650,19 @@ suite("Fold Execution Guards", () => {
 	test("executes exact unfold selection lines for expand mode", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
 
 		await runFoldCommand({ mode: "expand" }, regions, async (command, args) => {
-			executedCommands.push({ command, selectionLines: args.selectionLines });
-		});
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://expand");
 
 		assert.deepStrictEqual(executedCommands, [{
 			command: "editor.unfold",
+			levels: 1,
 			selectionLines: [2, 6, 12],
 		}]);
 	});
@@ -717,7 +785,8 @@ function createDuplicateSelectionFixture(): ReturnType<typeof normalizeSymbols> 
 }
 
 interface ExecutedCommand {
-	command: "editor.fold" | "editor.unfold" | "editor.toggleFold";
+	command: "editor.fold" | "editor.unfold";
+	levels: number;
 	selectionLines: number[];
 }
 


### PR DESCRIPTION
- track semantic fold state per document
- collapse mixed toggle targets together before expanding as a group
- use level-one fold commands to avoid parent escalation
- document current preserveCursorContext behaviour

Closes #22
Closes #4