### PR TITLE
feat(filters): relationship-aware targeting

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ The generic `semanticFold.collapse` command accepts one optional `args` object:
     "exactSymbolDepth": 2,
     "minSymbolDepth": 1,
     "maxSymbolDepth": 3,
-    "parentKinds": ["class"]
+    "parentKinds": ["class"],
+    "ancestorKinds": ["class"]
   }
 }
 ```
@@ -171,6 +172,21 @@ Add `exactSymbolDepth` when you only want methods at one level of the symbol tre
       "kinds": ["method"],
       "parentKinds": ["class"],
       "exactSymbolDepth": 2
+    }
+  }
+}
+```
+
+Toggle nested helper functions anywhere inside a class context:
+
+```json
+{
+  "key": "ctrl+alt+h",
+  "command": "semanticFold.collapse",
+  "args": {
+    "filter": {
+      "kinds": ["function"],
+      "ancestorKinds": ["class"]
     }
   }
 }
@@ -228,6 +244,7 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Run `semanticFold.collapse` with no args and confirm foldable symbol regions collapse.
 - Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.exactSymbolDepth: 2`; confirm second-level methods toggle without folding their parent class.
 - Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.parentKinds: ["class"]`; confirm class methods toggle while top-level helper functions stay visible.
+- Bind `semanticFold.collapse` with `filter.kinds: ["function"]` and `filter.ancestorKinds: ["class"]`; confirm nested helper functions inside a class context toggle while top-level helper functions stay visible.
 - Run `semanticFold.toggleMethodsInClasses`; confirm it behaves like the `method` plus `class` parent filter.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ The generic `semanticFold.collapse` command accepts one optional `args` object:
     "excludeKinds": ["unknown"],
     "exactSymbolDepth": 2,
     "minSymbolDepth": 1,
-    "maxSymbolDepth": 3
+    "maxSymbolDepth": 3,
+    "parentKinds": ["class"]
   }
 }
 ```
@@ -135,7 +136,16 @@ The `preserveCursorContext` field is accepted for payload compatibility, but Pha
 
 Toggle state is tracked for folds created through Semantic Fold commands. Manual folding, unfolding, or other extensions can make the tracked state incomplete, but the next semantic toggle collapses a mixed target set back into a consistent state before later toggles expand it as a group.
 
-Toggle second-level methods:
+Toggle methods whose immediate parent is a class:
+
+```json
+{
+  "key": "ctrl+alt+m",
+  "command": "semanticFold.toggleMethodsInClasses"
+}
+```
+
+The generic command equivalent is:
 
 ```json
 {
@@ -144,6 +154,22 @@ Toggle second-level methods:
   "args": {
     "filter": {
       "kinds": ["method"],
+      "parentKinds": ["class"]
+    }
+  }
+}
+```
+
+Add `exactSymbolDepth` when you only want methods at one level of the symbol tree:
+
+```json
+{
+  "key": "ctrl+alt+shift+m",
+  "command": "semanticFold.collapse",
+  "args": {
+    "filter": {
+      "kinds": ["method"],
+      "parentKinds": ["class"],
       "exactSymbolDepth": 2
     }
   }
@@ -201,6 +227,8 @@ Use a file with a top-level class, methods inside that class, a nested function 
 
 - Run `semanticFold.collapse` with no args and confirm foldable symbol regions collapse.
 - Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.exactSymbolDepth: 2`; confirm second-level methods toggle without folding their parent class.
+- Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.parentKinds: ["class"]`; confirm class methods toggle while top-level helper functions stay visible.
+- Run `semanticFold.toggleMethodsInClasses`; confirm it behaves like the `method` plus `class` parent filter.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
 - Use a filter with no matches; confirm the command leaves the editor unchanged.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ Some language providers return flat `SymbolInformation` results instead of hiera
 
 Flat fallback mode does not infer parent/child relationships. Parent, ancestor, and deeper symbol-depth filters require hierarchical provider data and may return no matches when only flat symbols are available.
 
+Relationship filters fail soft in that situation: `parentKinds` and `ancestorKinds` do not fabricate hierarchy from line ranges, indentation, or names. If no real parent chain exists, the command produces no matching regions and leaves the editor unchanged instead of folding misleading targets.
+
 ## Design decisions
 
 ### Why not semantic tokens first?

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
       {
         "command": "semanticFold.expand",
         "title": "Semantic Fold: Expand"
+      },
+      {
+        "command": "semanticFold.toggleMethodsInClasses",
+        "title": "Semantic Fold: Toggle Methods in Classes"
       }
     ]
   },

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -3,6 +3,14 @@ import { getRegions } from "../engine/regionCollector";
 import { runFoldCommand } from "../engine/foldExecutor";
 import { type CollapseArgs, normaliseArgs } from "../model/filters";
 
+const methodsInClassesArgs: CollapseArgs = {
+	filter: {
+		kinds: ["method"],
+		parentKinds: ["class"],
+	},
+	mode: "toggle",
+};
+
 export async function collapseCommand(args?: unknown): Promise<void> {
 	const editor = vscode.window.activeTextEditor;
 
@@ -13,6 +21,10 @@ export async function collapseCommand(args?: unknown): Promise<void> {
 	const regions = await getRegions(editor.document);
 
 	await runFoldCommand(normaliseArgs(args, getDefaultCollapseMode(args)), regions);
+}
+
+export async function toggleMethodsInClassesCommand(): Promise<void> {
+	await collapseCommand(methodsInClassesArgs);
 }
 
 export function getDefaultCollapseMode(args: unknown): CollapseArgs["mode"] {

--- a/src/engine/filterEngine.ts
+++ b/src/engine/filterEngine.ts
@@ -7,6 +7,7 @@ export function filterRegions(rootNodes: readonly RegionNode[], filter: Collapse
 	return regions.filter((region) => {
 		return matchesIncludedKind(region, filter)
 			&& !matchesExcludedKind(region, filter)
+			&& matchesParentKind(region, filter)
 			&& matchesSymbolDepth(region, filter);
 	});
 }
@@ -43,6 +44,14 @@ function matchesExcludedKind(region: RegionNode, filter: CollapseFilter): boolea
 	}
 
 	return filter.excludeKinds.includes(region.kind);
+}
+
+function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean {
+	if(!filter.parentKinds || filter.parentKinds.length === 0) {
+		return true;
+	}
+
+	return region.parent !== undefined && filter.parentKinds.includes(region.parent.kind);
 }
 
 function matchesSymbolDepth(region: RegionNode, filter: CollapseFilter): boolean {

--- a/src/engine/filterEngine.ts
+++ b/src/engine/filterEngine.ts
@@ -8,6 +8,7 @@ export function filterRegions(rootNodes: readonly RegionNode[], filter: Collapse
 		return matchesIncludedKind(region, filter)
 			&& !matchesExcludedKind(region, filter)
 			&& matchesParentKind(region, filter)
+			&& matchesAncestorKind(region, filter)
 			&& matchesSymbolDepth(region, filter);
 	});
 }
@@ -52,6 +53,28 @@ function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean 
 	}
 
 	return region.parent !== undefined && filter.parentKinds.includes(region.parent.kind);
+}
+
+function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolean {
+	if(!filter.ancestorKinds || filter.ancestorKinds.length === 0) {
+		return true;
+	}
+
+	return getAncestors(region).some((ancestor) => filter.ancestorKinds?.includes(ancestor.kind));
+}
+
+export function getAncestors(region: RegionNode): RegionNode[] {
+	const ancestors: RegionNode[] = [];
+	const visitedNodes = new Set<RegionNode>();
+	let ancestor = region.parent;
+
+	while(ancestor !== undefined && !visitedNodes.has(ancestor)) {
+		visitedNodes.add(ancestor);
+		ancestors.push(ancestor);
+		ancestor = ancestor.parent;
+	}
+
+	return ancestors;
 }
 
 function matchesSymbolDepth(region: RegionNode, filter: CollapseFilter): boolean {

--- a/src/engine/filterEngine.ts
+++ b/src/engine/filterEngine.ts
@@ -52,7 +52,9 @@ function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean 
 		return true;
 	}
 
-	return region.parent !== undefined && filter.parentKinds.includes(region.parent.kind);
+	const parent = getParent(region);
+
+	return parent !== undefined && filter.parentKinds.includes(parent.kind);
 }
 
 function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolean {
@@ -63,15 +65,27 @@ function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolea
 	return getAncestors(region).some((ancestor) => filter.ancestorKinds?.includes(ancestor.kind));
 }
 
+export function hasHierarchy(region: RegionNode): boolean {
+	return getParent(region) !== undefined || region.children.length > 0;
+}
+
+function getParent(region: RegionNode): RegionNode | undefined {
+	if(region.parent === region) {
+		return undefined;
+	}
+
+	return region.parent;
+}
+
 export function getAncestors(region: RegionNode): RegionNode[] {
 	const ancestors: RegionNode[] = [];
 	const visitedNodes = new Set<RegionNode>();
-	let ancestor = region.parent;
+	let ancestor = getParent(region);
 
 	while(ancestor !== undefined && !visitedNodes.has(ancestor)) {
 		visitedNodes.add(ancestor);
 		ancestors.push(ancestor);
-		ancestor = ancestor.parent;
+		ancestor = getParent(ancestor);
 	}
 
 	return ancestors;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,16 @@
 import * as vscode from "vscode";
-import { collapseCommand } from "./commands/collapse";
+import { collapseCommand, toggleMethodsInClassesCommand } from "./commands/collapse";
 import { expandCommand } from "./commands/expand";
 
 export function activate(context: vscode.ExtensionContext): void {
-    context.subscriptions.push(
-    	vscode.commands.registerCommand("semanticFold.collapse", collapseCommand),
-        vscode.commands.registerCommand("semanticFold.expand", expandCommand)
-    );
+	context.subscriptions.push(
+		vscode.commands.registerCommand("semanticFold.collapse", collapseCommand),
+		vscode.commands.registerCommand("semanticFold.expand", expandCommand),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleMethodsInClasses",
+			toggleMethodsInClassesCommand
+		)
+	);
 }
 
 export function deactivate(): void {}

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDefaultCollapseMode } from "../commands/collapse";
-import { filterRegions, flattenRegions, getAncestors } from "../engine/filterEngine";
+import { filterRegions, flattenRegions, getAncestors, hasHierarchy } from "../engine/filterEngine";
 import {
 	collectFoldableRegions,
 	collectSelectionLines,
@@ -506,6 +506,27 @@ suite("Region Filtering", () => {
 		);
 	});
 
+	test("does not fabricate parent or ancestor matches for flat fallback symbols", () => {
+		const regions = createFlatFallbackFixture();
+		const flatRegions = flattenRegions(regions);
+
+		assert.ok(flatRegions.every((region) => !hasHierarchy(region)));
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			[]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				ancestorKinds: ["class"],
+			}).map((region) => region.name),
+			[]
+		);
+	});
+
 	test("returns regions whose immediate parent kind matches the requested parent kinds", () => {
 		const regions = createPhaseOneFixture();
 
@@ -618,6 +639,24 @@ suite("Region Filtering", () => {
 				ancestorKinds: ["class"],
 			}).map((region) => region.name),
 			["formatPayload"]
+		);
+	});
+
+	test("ignores self-parent links instead of treating them as valid hierarchy", () => {
+		const regions = createFlatFallbackFixture();
+		const runRegion = regions[1];
+
+		runRegion.parent = runRegion;
+
+		assert.strictEqual(hasHierarchy(runRegion), false);
+		assert.deepStrictEqual(getAncestors(runRegion), []);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["method"],
+				ancestorKinds: ["method"],
+			}).map((region) => region.name),
+			[]
 		);
 	});
 });
@@ -763,6 +802,27 @@ suite("Fold Execution Guards", () => {
 				selectionLines: args.selectionLines,
 			});
 		}, foldState, "test://empty");
+
+		assert.deepStrictEqual(executedCommands, []);
+	});
+
+	test("does not execute any command when relationship filters cannot match flat fallback symbols", async () => {
+		const regions = createFlatFallbackFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		await runFoldCommand({
+			filter: {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			},
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://flat-relationship");
 
 		assert.deepStrictEqual(executedCommands, []);
 	});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -22,6 +22,7 @@ suite("Semantic Fold Foundation", () => {
 
 		assert.ok(commands.includes("semanticFold.collapse"));
 		assert.ok(commands.includes("semanticFold.expand"));
+		assert.ok(commands.includes("semanticFold.toggleMethodsInClasses"));
 	});
 });
 
@@ -188,6 +189,7 @@ suite("Command Argument Normalisation", () => {
 					excludeKinds: ["unknown"],
 					exactSymbolDepth: 2,
 					minSymbolDepth: 1,
+					parentKinds: ["class"],
 					nameRegex: "^handle",
 				},
 				preserveCursorContext: true,
@@ -198,6 +200,7 @@ suite("Command Argument Normalisation", () => {
 					excludeKinds: ["unknown"],
 					exactSymbolDepth: 2,
 					minSymbolDepth: 1,
+					parentKinds: ["class"],
 					nameRegex: "^handle",
 				},
 				mode: "collapse",
@@ -498,6 +501,62 @@ suite("Region Filtering", () => {
 		assert.deepStrictEqual(
 			filterRegions(regions, { exactSymbolDepth: 2 }).map((region) => region.name),
 			[]
+		);
+	});
+
+	test("returns regions whose immediate parent kind matches the requested parent kinds", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, { parentKinds: ["class"] }).map((region) => region.name),
+			["constructor", "handle", "ViewModel", "render"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["handle", "render"]
+		);
+	});
+
+	test("keeps top-level helpers visible when filtering methods inside classes", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["handle", "render"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			[]
+		);
+	});
+
+	test("combines parent-kind filters with kind and symbol-depth filters", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+				exactSymbolDepth: 2,
+			}).map((region) => region.name),
+			["handle"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+				exactSymbolDepth: 3,
+			}).map((region) => region.name),
+			["render"]
 		);
 	});
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDefaultCollapseMode } from "../commands/collapse";
-import { filterRegions, flattenRegions } from "../engine/filterEngine";
+import { filterRegions, flattenRegions, getAncestors } from "../engine/filterEngine";
 import {
 	collectFoldableRegions,
 	collectSelectionLines,
@@ -189,6 +189,7 @@ suite("Command Argument Normalisation", () => {
 					excludeKinds: ["unknown"],
 					exactSymbolDepth: 2,
 					minSymbolDepth: 1,
+					ancestorKinds: ["class"],
 					parentKinds: ["class"],
 					nameRegex: "^handle",
 				},
@@ -200,6 +201,7 @@ suite("Command Argument Normalisation", () => {
 					excludeKinds: ["unknown"],
 					exactSymbolDepth: 2,
 					minSymbolDepth: 1,
+					ancestorKinds: ["class"],
 					parentKinds: ["class"],
 					nameRegex: "^handle",
 				},
@@ -557,6 +559,65 @@ suite("Region Filtering", () => {
 				exactSymbolDepth: 3,
 			}).map((region) => region.name),
 			["render"]
+		);
+	});
+
+	test("returns regions whose broader ancestor context matches requested kinds", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, { ancestorKinds: ["class"] }).map((region) => region.name),
+			["constructor", "handle", "formatPayload", "ViewModel", "render"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				ancestorKinds: ["class"],
+			}).map((region) => region.name),
+			["formatPayload"]
+		);
+	});
+
+	test("combines ancestor filters with kind, depth, and parent filters", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+				ancestorKinds: ["class"],
+				exactSymbolDepth: 3,
+			}).map((region) => region.name),
+			["render"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				parentKinds: ["method"],
+				ancestorKinds: ["class"],
+				exactSymbolDepth: 3,
+			}).map((region) => region.name),
+			["formatPayload"]
+		);
+	});
+
+	test("walks ancestor chains safely when a malformed tree has a parent cycle", () => {
+		const regions = createPhaseOneFixture();
+		const controllerRegion = regions[0];
+		const handleRegion = controllerRegion.children[1];
+
+		controllerRegion.parent = handleRegion;
+
+		assert.deepStrictEqual(
+			getAncestors(handleRegion).map((region) => region.name),
+			["Controller", "handle"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				ancestorKinds: ["class"],
+			}).map((region) => region.name),
+			["formatPayload"]
 		);
 	});
 });


### PR DESCRIPTION
- Support methods inside classes
- Support ancestor context filters
- Fail soft for weak hierarchy

Closes #23
Closes #24
Closes #25
Closes #5