### PR TITLE
Phase 2 - Relational Filtering

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,8 @@ The generic `semanticFold.collapse` command accepts one optional `args` object:
     "exactSymbolDepth": 2,
     "minSymbolDepth": 1,
     "maxSymbolDepth": 3,
-    "parentKinds": ["class"]
+    "parentKinds": ["class"],
+    "ancestorKinds": ["class"]
   }
 }
 ```
@@ -171,6 +172,21 @@ Add `exactSymbolDepth` when you only want methods at one level of the symbol tre
       "kinds": ["method"],
       "parentKinds": ["class"],
       "exactSymbolDepth": 2
+    }
+  }
+}
+```
+
+Toggle nested helper functions anywhere inside a class context:
+
+```json
+{
+  "key": "ctrl+alt+h",
+  "command": "semanticFold.collapse",
+  "args": {
+    "filter": {
+      "kinds": ["function"],
+      "ancestorKinds": ["class"]
     }
   }
 }
@@ -228,6 +244,7 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Run `semanticFold.collapse` with no args and confirm foldable symbol regions collapse.
 - Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.exactSymbolDepth: 2`; confirm second-level methods toggle without folding their parent class.
 - Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.parentKinds: ["class"]`; confirm class methods toggle while top-level helper functions stay visible.
+- Bind `semanticFold.collapse` with `filter.kinds: ["function"]` and `filter.ancestorKinds: ["class"]`; confirm nested helper functions inside a class context toggle while top-level helper functions stay visible.
 - Run `semanticFold.toggleMethodsInClasses`; confirm it behaves like the `method` plus `class` parent filter.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.

--- a/README.md
+++ b/README.md
@@ -123,14 +123,17 @@ The generic `semanticFold.collapse` command accepts one optional `args` object:
     "exactSymbolDepth": 2,
     "minSymbolDepth": 1,
     "maxSymbolDepth": 3
-  },
-  "preserveCursorContext": true
+  }
 }
 ```
 
 Invalid or incomplete fields are ignored. For example, unknown kind strings, non-integer depths, malformed `nameRegex` values, and non-object payloads fall back to the safest valid subset instead of failing the command.
 
-Keybinding payloads default to toggle mode: pressing the same binding again unfolds the same matching regions. Set `"mode": "collapse"`, `"mode": "expand"`, or `"mode": "toggle"` in the payload to force a specific action.
+Keybinding payloads default to toggle mode. If any matching target is expanded, pressing the binding collapses every matching target; when all matching targets are collapsed, pressing it expands them together. Set `"mode": "collapse"`, `"mode": "expand"`, or `"mode": "toggle"` in the payload to force a specific action.
+
+The `preserveCursorContext` field is accepted for payload compatibility, but Phase 1 folding does not protect the focused region from being folded. If the cursor is inside a folded target, VS Code moves the selection to visible fold context instead of reopening that method.
+
+Toggle state is tracked for folds created through Semantic Fold commands. Manual folding, unfolding, or other extensions can make the tracked state incomplete, but the next semantic toggle collapses a mixed target set back into a consistent state before later toggles expand it as a group.
 
 Toggle second-level methods:
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ This should fold each method directly, rather than recursively folding everythin
 The normalised semantic category of a region, such as:
 
 - `class`
+- `struct`
 - `interface`
 - `enum`
 - `function`
@@ -78,11 +79,12 @@ The normalised semantic category of a region, such as:
 - `namespace`
 - `property`
 - `field`
+- `object`
 - `import`
 - `comment`
 - `region`
 
-Semantic Fold preserves distinctions such as `function`, `method`, `constructor`, `property`, and `field` when the active language extension exposes them through VS Code's document-symbol provider. Provider quality varies by language and extension, so weak providers may report less precise kinds or fall back to unknown categories.
+Semantic Fold preserves distinctions such as `struct`, `function`, `method`, `constructor`, `property`, `field`, `variable`, and `object` when the active language extension exposes them through VS Code's document-symbol provider. Provider quality varies by language and extension, so weak providers may report less precise kinds or fall back to unknown categories.
 
 ### Symbol depth
 
@@ -136,6 +138,18 @@ Payloads passed to `semanticFold.collapse` default to toggle mode for keybinding
 The `preserveCursorContext` field is accepted for payload compatibility, but Phase 1 folding does not protect the focused region from being folded. If the cursor is inside a folded target, VS Code moves the selection to visible fold context instead of reopening that method.
 
 Toggle state is tracked for folds created through Semantic Fold commands. Manual folding, unfolding, or other extensions can make the tracked state incomplete, but the next semantic toggle collapses a mixed target set back into a consistent state before later toggles expand it as a group.
+
+## Convenience commands
+
+These commands are available from the Command Palette and use the same filter pipeline as the generic commands:
+
+| Command | Intended behaviour |
+| --- | --- |
+| `semanticFold.toggleMethodsInClasses` | Toggle methods whose immediate parent is a class. |
+| `semanticFold.toggleClassMembers` | Toggle constructors, methods, properties, and fields whose immediate parent is a class. |
+| `semanticFold.toggleTypes` | Toggle provider-exposed class, struct, interface, and enum regions. Type aliases are included only if the language provider reports them as one of those symbol kinds. |
+| `semanticFold.toggleVariables` | Toggle variable, constant, and object regions that have foldable symbol ranges. |
+| `semanticFold.toggleFunctionsInVariables` | Toggle function and method regions anywhere inside a variable or object ancestor context, such as functions inside an object literal assigned to a variable. |
 
 Toggle methods whose immediate parent is a class:
 
@@ -246,6 +260,12 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.parentKinds: ["class"]`; confirm class methods toggle while top-level helper functions stay visible.
 - Bind `semanticFold.collapse` with `filter.kinds: ["function"]` and `filter.ancestorKinds: ["class"]`; confirm nested helper functions inside a class context toggle while top-level helper functions stay visible.
 - Run `semanticFold.toggleMethodsInClasses`; confirm it behaves like the `method` plus `class` parent filter.
+- Run `semanticFold.toggleClassMembers`; confirm it toggles direct class members such as constructors, methods, properties, and fields.
+- Run `semanticFold.toggleFunctionsInClasses`; confirm it toggles nested helper functions inside class context while top-level helper functions stay visible.
+- Run `semanticFold.toggleStructs`; confirm provider-exposed struct regions toggle if the active language reports structs separately from classes.
+- Run `semanticFold.toggleTypes`; confirm class, struct, interface, and enum regions toggle.
+- Run `semanticFold.toggleVariables`; confirm foldable variable, constant, and object regions toggle.
+- Run `semanticFold.toggleFunctionsInVariables`; confirm function and method regions inside variable or object contexts toggle when the provider exposes that hierarchy.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
 - Run `semanticFold.toggle` with the same filter; confirm it targets the same methods as collapse and expand.

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ This may be useful later for advanced workflows, but the main MVP is based on **
 
 ## Keybinding payload examples
 
-The generic `semanticFold.collapse` command accepts one optional `args` object:
+The generic `semanticFold.collapse`, `semanticFold.expand`, and `semanticFold.toggle` commands all accept the same optional `args` object:
 
 ```json
 {
@@ -131,7 +131,7 @@ The generic `semanticFold.collapse` command accepts one optional `args` object:
 
 Invalid or incomplete fields are ignored. For example, unknown kind strings, non-integer depths, malformed `nameRegex` values, and non-object payloads fall back to the safest valid subset instead of failing the command.
 
-Keybinding payloads default to toggle mode. If any matching target is expanded, pressing the binding collapses every matching target; when all matching targets are collapsed, pressing it expands them together. Set `"mode": "collapse"`, `"mode": "expand"`, or `"mode": "toggle"` in the payload to force a specific action.
+Payloads passed to `semanticFold.collapse` default to toggle mode for keybinding ergonomics. If any matching target is expanded, pressing the binding collapses every matching target; when all matching targets are collapsed, pressing it expands them together. Set `"mode": "collapse"`, `"mode": "expand"`, or `"mode": "toggle"` in the payload to force a specific action, or bind `semanticFold.toggle` directly when you want a dedicated toggle command.
 
 The `preserveCursorContext` field is accepted for payload compatibility, but Phase 1 folding does not protect the focused region from being folded. If the cursor is inside a folded target, VS Code moves the selection to visible fold context instead of reopening that method.
 
@@ -151,7 +151,7 @@ The generic command equivalent is:
 ```json
 {
   "key": "ctrl+alt+m",
-  "command": "semanticFold.collapse",
+  "command": "semanticFold.toggle",
   "args": {
     "filter": {
       "kinds": ["method"],
@@ -248,6 +248,7 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Run `semanticFold.toggleMethodsInClasses`; confirm it behaves like the `method` plus `class` parent filter.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
+- Run `semanticFold.toggle` with the same filter; confirm it targets the same methods as collapse and expand.
 - Use a filter with no matches; confirm the command leaves the editor unchanged.
 
 ### Targeted Folding Versus Recursive Folding

--- a/README.md
+++ b/README.md
@@ -122,7 +122,8 @@ The generic `semanticFold.collapse` command accepts one optional `args` object:
     "excludeKinds": ["unknown"],
     "exactSymbolDepth": 2,
     "minSymbolDepth": 1,
-    "maxSymbolDepth": 3
+    "maxSymbolDepth": 3,
+    "parentKinds": ["class"]
   }
 }
 ```
@@ -135,7 +136,16 @@ The `preserveCursorContext` field is accepted for payload compatibility, but Pha
 
 Toggle state is tracked for folds created through Semantic Fold commands. Manual folding, unfolding, or other extensions can make the tracked state incomplete, but the next semantic toggle collapses a mixed target set back into a consistent state before later toggles expand it as a group.
 
-Toggle second-level methods:
+Toggle methods whose immediate parent is a class:
+
+```json
+{
+  "key": "ctrl+alt+m",
+  "command": "semanticFold.toggleMethodsInClasses"
+}
+```
+
+The generic command equivalent is:
 
 ```json
 {
@@ -144,6 +154,22 @@ Toggle second-level methods:
   "args": {
     "filter": {
       "kinds": ["method"],
+      "parentKinds": ["class"]
+    }
+  }
+}
+```
+
+Add `exactSymbolDepth` when you only want methods at one level of the symbol tree:
+
+```json
+{
+  "key": "ctrl+alt+shift+m",
+  "command": "semanticFold.collapse",
+  "args": {
+    "filter": {
+      "kinds": ["method"],
+      "parentKinds": ["class"],
       "exactSymbolDepth": 2
     }
   }
@@ -201,6 +227,8 @@ Use a file with a top-level class, methods inside that class, a nested function 
 
 - Run `semanticFold.collapse` with no args and confirm foldable symbol regions collapse.
 - Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.exactSymbolDepth: 2`; confirm second-level methods toggle without folding their parent class.
+- Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.parentKinds: ["class"]`; confirm class methods toggle while top-level helper functions stay visible.
+- Run `semanticFold.toggleMethodsInClasses`; confirm it behaves like the `method` plus `class` parent filter.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
 - Use a filter with no matches; confirm the command leaves the editor unchanged.

--- a/README.md
+++ b/README.md
@@ -331,6 +331,8 @@ Some language providers return flat `SymbolInformation` results instead of hiera
 
 Flat fallback mode does not infer parent/child relationships. Parent, ancestor, and deeper symbol-depth filters require hierarchical provider data and may return no matches when only flat symbols are available.
 
+Relationship filters fail soft in that situation: `parentKinds` and `ancestorKinds` do not fabricate hierarchy from line ranges, indentation, or names. If no real parent chain exists, the command produces no matching regions and leaves the editor unchanged instead of folding misleading targets.
+
 ## Design decisions
 
 ### Why not semantic tokens first?

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The main use case is simple:
 
 VS Code's built-in folding is useful, but it is mostly oriented around lexical folding depth and general folding commands.
 
-That works for broad collapse operations, but it breaks down when you want more targeted behavior such as:
+That works for broad collapse operations, but it breaks down when you want more targeted behaviour such as:
 
 - collapse only methods
 - collapse only top-level classes
@@ -41,9 +41,9 @@ These are not first-version goals:
 - full custom parsing for all languages
 - owning fold state globally across every provider and extension
 
-## Core behavior
+## Core Behaviour
 
-Semantic Fold discovers structural regions in the active document and normalizes them into an internal tree.
+Semantic Fold discovers structural regions in the active document and normalises them into an internal tree.
 
 It primarily uses:
 
@@ -67,7 +67,7 @@ This should fold each method directly, rather than recursively folding everythin
 
 ### Symbol kind
 
-The normalized semantic category of a region, such as:
+The normalised semantic category of a region, such as:
 
 - `class`
 - `interface`
@@ -177,6 +177,37 @@ Toggle implementation details below the top level:
 }
 ```
 
+## Phase 1 Validation
+
+Phase 1 is the symbol-driven MVP. It proves that Semantic Fold can collect document symbols, convert them into one internal region model, filter those regions by kind and symbol depth, and apply folding only to the exact matching regions.
+
+The core workflow is:
+
+```text
+active document
+  -> collect document symbols
+  -> normalise into RegionNode tree
+  -> filter by kind and symbol depth
+  -> collect exact selection lines
+  -> collapse, expand, or toggle matching regions
+```
+
+### Main Command Checklist
+
+Use a file with a top-level class, methods inside that class, a nested function inside one method, and a top-level function.
+
+- Run `semanticFold.collapse` with no args and confirm foldable symbol regions collapse.
+- Bind `semanticFold.collapse` with `filter.kinds: ["method"]` and `filter.exactSymbolDepth: 2`; confirm second-level methods toggle without folding their parent class.
+- Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
+- Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
+- Use a filter with no matches; confirm the command leaves the editor unchanged.
+
+### Targeted Folding Versus Recursive Folding
+
+Recursive level folding starts from a broad location or depth and can fold child ranges inside the selected region. That is useful for quickly hiding everything below a level, but it is not precise enough for workflows such as reviewing only method signatures.
+
+Targeted folding starts from the symbol provider. Semantic Fold filters symbols first, then sends VS Code the exact start lines for the matching regions. Folding methods this way hides each method as a whole method; when one method is expanded, its body is visible instead of remaining full of recursively collapsed child ranges.
+
 ## MVP scope
 
 The first version focuses on the active editor and aims to support languages with decent document-symbol providers, such as:
@@ -196,7 +227,7 @@ active document
   -> document symbols
   -> folding ranges
   -> semantic tokens (optional refinement)
-  -> normalize into RegionNode tree
+  -> normalise into RegionNode tree
   -> filter by kinds / depth / parent kinds / ancestors
   -> fold exact matching regions
 ```
@@ -206,7 +237,7 @@ active document
 ### Phase 1: symbol-driven MVP
 
 - collect document symbols
-- normalize to `RegionNode`
+- normalise to `RegionNode`
 - compute symbol depth
 - filter by kind and depth
 - fold matching regions
@@ -334,10 +365,10 @@ Open the workspace in VS Code and launch the extension host from the debugger.
 
 - [x] Scaffold extension
 - [x] Implement symbol collection
-- [x] Normalize `DocumentSymbol` trees
+- [x] Normalise `DocumentSymbol` trees
 - [x] Add filter engine
-- [ ] Add targeted collapse execution
-- [ ] Add keybinding-ready generic command
+- [x] Add targeted collapse execution
+- [x] Add keybinding-ready generic command
 - [ ] Add convenience commands
 - [ ] Add imports/comments/regions support
 - [ ] Add semantic-token refinement

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semantic-fold",
-  "version": "0.0.1-dev",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semantic-fold",
-      "version": "0.0.1-dev",
+      "version": "0.1.0",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,10 @@
         "title": "Semantic Fold: Expand"
       },
       {
+        "command": "semanticFold.toggle",
+        "title": "Semantic Fold: Toggle"
+      },
+      {
         "command": "semanticFold.toggleMethodsInClasses",
         "title": "Semantic Fold: Toggle Methods in Classes"
       }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,26 @@
       {
         "command": "semanticFold.toggleMethodsInClasses",
         "title": "Semantic Fold: Toggle Methods in Classes"
+      },
+      {
+        "command": "semanticFold.toggleClassMembers",
+        "title": "Semantic Fold: Toggle Class Members"
+      },
+      {
+        "command": "semanticFold.toggleFunctionsInClasses",
+        "title": "Semantic Fold: Toggle Functions in Classes"
+      },
+      {
+        "command": "semanticFold.toggleTypes",
+        "title": "Semantic Fold: Toggle Types"
+      },
+      {
+        "command": "semanticFold.toggleVariables",
+        "title": "Semantic Fold: Toggle Variables"
+      },
+      {
+        "command": "semanticFold.toggleFunctionsInVariables",
+        "title": "Semantic Fold: Toggle Functions in Variables"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -19,6 +19,10 @@
       {
         "command": "semanticFold.expand",
         "title": "Semantic Fold: Expand"
+      },
+      {
+        "command": "semanticFold.toggleMethodsInClasses",
+        "title": "Semantic Fold: Toggle Methods in Classes"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "semantic-fold",
   "displayName": "Semantic Fold",
   "description": "Policy-driven code folding for VS Code",
-  "version": "0.0.1-dev",
+  "version": "0.1.0",
   "engines": {
     "vscode": "^1.111.0"
   },

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -3,6 +3,14 @@ import { getRegions } from "../engine/regionCollector";
 import { runFoldCommand } from "../engine/foldExecutor";
 import { type CollapseArgs, normaliseArgs } from "../model/filters";
 
+const methodsInClassesArgs: CollapseArgs = {
+	filter: {
+		kinds: ["method"],
+		parentKinds: ["class"],
+	},
+	mode: "toggle",
+};
+
 export async function collapseCommand(args?: unknown): Promise<void> {
 	const editor = vscode.window.activeTextEditor;
 
@@ -13,6 +21,10 @@ export async function collapseCommand(args?: unknown): Promise<void> {
 	const regions = await getRegions(editor.document);
 
 	await runFoldCommand(normaliseArgs(args, getDefaultCollapseMode(args)), regions);
+}
+
+export async function toggleMethodsInClassesCommand(): Promise<void> {
+	await collapseCommand(methodsInClassesArgs);
 }
 
 export function getDefaultCollapseMode(args: unknown): CollapseArgs["mode"] {

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -1,7 +1,5 @@
-import * as vscode from "vscode";
-import { getRegions } from "../engine/regionCollector";
-import { runFoldCommand } from "../engine/foldExecutor";
-import { type CollapseArgs, normaliseArgs } from "../model/filters";
+import { type CollapseArgs } from "../model/filters";
+import { runFoldCommand } from "./foldCommand";
 
 const methodsInClassesArgs: CollapseArgs = {
 	filter: {
@@ -12,15 +10,7 @@ const methodsInClassesArgs: CollapseArgs = {
 };
 
 export async function collapseCommand(args?: unknown): Promise<void> {
-	const editor = vscode.window.activeTextEditor;
-
-	if(!editor) {
-		return;
-	}
-
-	const regions = await getRegions(editor.document);
-
-	await runFoldCommand(normaliseArgs(args, getDefaultCollapseMode(args)), regions);
+	await runFoldCommand(args, getDefaultCollapseMode(args));
 }
 
 export async function toggleMethodsInClassesCommand(): Promise<void> {

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -3,8 +3,38 @@ import { runFoldCommand } from "./foldCommand";
 
 const methodsInClassesArgs: CollapseArgs = {
 	filter: {
-		kinds: ["method"],
+		kinds: ["method", "function"],
 		parentKinds: ["class"],
+	},
+	mode: "toggle",
+};
+
+const classMembersArgs: CollapseArgs = {
+	filter: {
+		kinds: ["constructor", "method", "property", "field"],
+		parentKinds: ["class"],
+	},
+	mode: "toggle",
+};
+
+const typesArgs: CollapseArgs = {
+	filter: {
+		kinds: ["class", "struct", "interface", "enum"],
+	},
+	mode: "toggle",
+};
+
+const variablesArgs: CollapseArgs = {
+	filter: {
+		kinds: ["variable", "object"],
+	},
+	mode: "toggle",
+};
+
+const functionsInVariablesArgs: CollapseArgs = {
+	filter: {
+		kinds: ["function", "method"],
+		ancestorKinds: ["variable", "object"],
 	},
 	mode: "toggle",
 };
@@ -15,6 +45,22 @@ export async function collapseCommand(args?: unknown): Promise<void> {
 
 export async function toggleMethodsInClassesCommand(): Promise<void> {
 	await collapseCommand(methodsInClassesArgs);
+}
+
+export async function toggleClassMembersCommand(): Promise<void> {
+	await collapseCommand(classMembersArgs);
+}
+
+export async function toggleTypesCommand(): Promise<void> {
+	await collapseCommand(typesArgs);
+}
+
+export async function toggleVariablesCommand(): Promise<void> {
+	await collapseCommand(variablesArgs);
+}
+
+export async function toggleFunctionsInVariablesCommand(): Promise<void> {
+	await collapseCommand(functionsInVariablesArgs);
 }
 
 export function getDefaultCollapseMode(args: unknown): CollapseArgs["mode"] {

--- a/src/commands/expand.ts
+++ b/src/commands/expand.ts
@@ -1,16 +1,5 @@
-import * as vscode from "vscode";
-import { getRegions } from "../engine/regionCollector";
-import { runFoldCommand } from "../engine/foldExecutor";
-import { normaliseArgs } from "../model/filters";
+import { runFoldCommand } from "./foldCommand";
 
 export async function expandCommand(args?: unknown): Promise<void> {
-	const editor = vscode.window.activeTextEditor;
-
-	if(!editor) {
-		return;
-	}
-
-	const regions = await getRegions(editor.document);
-
-	await runFoldCommand(normaliseArgs(args, "expand"), regions);
+	await runFoldCommand(args, "expand");
 }

--- a/src/commands/foldCommand.ts
+++ b/src/commands/foldCommand.ts
@@ -1,0 +1,15 @@
+import * as vscode from "vscode";
+import { getRegions } from "../engine/regionCollector";
+import { execFoldCommand } from "../engine/foldExecutor";
+import { type CollapseArgs, normaliseArgs } from "../model/filters";
+
+export async function runFoldCommand(args: unknown, defaultMode: CollapseArgs["mode"]): Promise<void> {
+	const editor = vscode.window.activeTextEditor;
+
+	if(!editor) {
+		return;
+	}
+	
+	const regions = await getRegions(editor.document);
+	await execFoldCommand(normaliseArgs(args, defaultMode), regions);
+}

--- a/src/commands/toggle.ts
+++ b/src/commands/toggle.ts
@@ -1,0 +1,5 @@
+import { runFoldCommand } from "./foldCommand";
+
+export async function toggleCommand(args?: unknown): Promise<void> {
+	await runFoldCommand(args, "toggle");
+}

--- a/src/engine/filterEngine.ts
+++ b/src/engine/filterEngine.ts
@@ -7,6 +7,7 @@ export function filterRegions(rootNodes: readonly RegionNode[], filter: Collapse
 	return regions.filter((region) => {
 		return matchesIncludedKind(region, filter)
 			&& !matchesExcludedKind(region, filter)
+			&& matchesParentKind(region, filter)
 			&& matchesSymbolDepth(region, filter);
 	});
 }
@@ -43,6 +44,14 @@ function matchesExcludedKind(region: RegionNode, filter: CollapseFilter): boolea
 	}
 
 	return filter.excludeKinds.includes(region.kind);
+}
+
+function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean {
+	if(!filter.parentKinds || filter.parentKinds.length === 0) {
+		return true;
+	}
+
+	return region.parent !== undefined && filter.parentKinds.includes(region.parent.kind);
 }
 
 function matchesSymbolDepth(region: RegionNode, filter: CollapseFilter): boolean {

--- a/src/engine/filterEngine.ts
+++ b/src/engine/filterEngine.ts
@@ -8,6 +8,7 @@ export function filterRegions(rootNodes: readonly RegionNode[], filter: Collapse
 		return matchesIncludedKind(region, filter)
 			&& !matchesExcludedKind(region, filter)
 			&& matchesParentKind(region, filter)
+			&& matchesAncestorKind(region, filter)
 			&& matchesSymbolDepth(region, filter);
 	});
 }
@@ -52,6 +53,28 @@ function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean 
 	}
 
 	return region.parent !== undefined && filter.parentKinds.includes(region.parent.kind);
+}
+
+function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolean {
+	if(!filter.ancestorKinds || filter.ancestorKinds.length === 0) {
+		return true;
+	}
+
+	return getAncestors(region).some((ancestor) => filter.ancestorKinds?.includes(ancestor.kind));
+}
+
+export function getAncestors(region: RegionNode): RegionNode[] {
+	const ancestors: RegionNode[] = [];
+	const visitedNodes = new Set<RegionNode>();
+	let ancestor = region.parent;
+
+	while(ancestor !== undefined && !visitedNodes.has(ancestor)) {
+		visitedNodes.add(ancestor);
+		ancestors.push(ancestor);
+		ancestor = ancestor.parent;
+	}
+
+	return ancestors;
 }
 
 function matchesSymbolDepth(region: RegionNode, filter: CollapseFilter): boolean {

--- a/src/engine/filterEngine.ts
+++ b/src/engine/filterEngine.ts
@@ -52,7 +52,9 @@ function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean 
 		return true;
 	}
 
-	return region.parent !== undefined && filter.parentKinds.includes(region.parent.kind);
+	const parent = getParent(region);
+
+	return parent !== undefined && filter.parentKinds.includes(parent.kind);
 }
 
 function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolean {
@@ -63,15 +65,27 @@ function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolea
 	return getAncestors(region).some((ancestor) => filter.ancestorKinds?.includes(ancestor.kind));
 }
 
+export function hasHierarchy(region: RegionNode): boolean {
+	return getParent(region) !== undefined || region.children.length > 0;
+}
+
+function getParent(region: RegionNode): RegionNode | undefined {
+	if(region.parent === region) {
+		return undefined;
+	}
+
+	return region.parent;
+}
+
 export function getAncestors(region: RegionNode): RegionNode[] {
 	const ancestors: RegionNode[] = [];
 	const visitedNodes = new Set<RegionNode>();
-	let ancestor = region.parent;
+	let ancestor = getParent(region);
 
 	while(ancestor !== undefined && !visitedNodes.has(ancestor)) {
 		visitedNodes.add(ancestor);
 		ancestors.push(ancestor);
-		ancestor = ancestor.parent;
+		ancestor = getParent(ancestor);
 	}
 
 	return ancestors;

--- a/src/engine/foldExecutor.ts
+++ b/src/engine/foldExecutor.ts
@@ -95,7 +95,7 @@ export function collectSelectionLines(regions: readonly RegionNode[]): number[] 
 		.sort((left, right) => left - right);
 }
 
-export async function runFoldCommand(
+export async function execFoldCommand(
 	args: CollapseArgs,
 	rootNodes: readonly RegionNode[] = [],
 	executeCommand: FoldCommandExecutor = defaultFoldCommandExecutor,

--- a/src/engine/foldExecutor.ts
+++ b/src/engine/foldExecutor.ts
@@ -3,12 +3,69 @@ import type { CollapseArgs } from "../model/filters";
 import type { RegionNode } from "../model/region";
 import { filterRegions } from "./filterEngine";
 
-type FoldCommand = "editor.fold" | "editor.unfold" | "editor.toggleFold";
+type FoldCommand = "editor.fold" | "editor.unfold";
+
+interface FoldCommandArgs {
+	selectionLines: number[];
+	levels: number;
+}
 
 export type FoldCommandExecutor = (
 	command: FoldCommand,
-	args: { selectionLines: number[] }
+	args: FoldCommandArgs
 ) => Thenable<unknown>;
+
+export class TrackedFoldState {
+	private readonly collapsedLinesByDocument = new Map<string, Set<number>>();
+
+	public areAllCollapsed(documentKey: string, selectionLines: readonly number[]): boolean {
+		const collapsedLines = this.collapsedLinesByDocument.get(documentKey);
+
+		if(!collapsedLines || selectionLines.length === 0) {
+			return false;
+		}
+
+		return selectionLines.every((line) => collapsedLines.has(line));
+	}
+
+	public markCollapsed(documentKey: string, selectionLines: readonly number[]): void {
+		const collapsedLines = this.getCollapsedLines(documentKey);
+
+		for(const line of selectionLines) {
+			collapsedLines.add(line);
+		}
+	}
+
+	public markExpanded(documentKey: string, selectionLines: readonly number[]): void {
+		const collapsedLines = this.collapsedLinesByDocument.get(documentKey);
+
+		if(!collapsedLines) {
+			return;
+		}
+
+		for(const line of selectionLines) {
+			collapsedLines.delete(line);
+		}
+
+		if(collapsedLines.size === 0) {
+			this.collapsedLinesByDocument.delete(documentKey);
+		}
+	}
+
+	private getCollapsedLines(documentKey: string): Set<number> {
+		const existingLines = this.collapsedLinesByDocument.get(documentKey);
+
+		if(existingLines) {
+			return existingLines;
+		}
+
+		const collapsedLines = new Set<number>();
+
+		this.collapsedLinesByDocument.set(documentKey, collapsedLines);
+
+		return collapsedLines;
+	}
+}
 
 export function isFoldableRegion(region: RegionNode): boolean {
 	return Number.isInteger(region.rangeStartLine)
@@ -41,7 +98,9 @@ export function collectSelectionLines(regions: readonly RegionNode[]): number[] 
 export async function runFoldCommand(
 	args: CollapseArgs,
 	rootNodes: readonly RegionNode[] = [],
-	executeCommand: FoldCommandExecutor = defaultFoldCommandExecutor
+	executeCommand: FoldCommandExecutor = defaultFoldCommandExecutor,
+	foldState: TrackedFoldState = defaultFoldState,
+	documentKey: string = getActiveDocumentKey()
 ): Promise<void> {
 	const selectionLines = collectSelectionLines(selectFoldableRegions(args, rootNodes));
 
@@ -49,7 +108,10 @@ export async function runFoldCommand(
 		return;
 	}
 
-	await executeCommand(getFoldCommand(args), { selectionLines });
+	const command = getFoldCommand(args, selectionLines, foldState, documentKey);
+
+	await executeCommand(command, { selectionLines, levels: 1 });
+	updateTrackedFoldState(command, selectionLines, foldState, documentKey);
 }
 
 function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]): void {
@@ -62,13 +124,22 @@ function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]
 	}
 }
 
-function getFoldCommand(args: CollapseArgs): FoldCommand {
+function getFoldCommand(
+	args: CollapseArgs,
+	selectionLines: readonly number[],
+	foldState: TrackedFoldState,
+	documentKey: string
+): FoldCommand {
 	if(args.mode === "expand") {
 		return "editor.unfold";
 	}
 
 	if(args.mode === "toggle") {
-		return "editor.toggleFold";
+		if(foldState.areAllCollapsed(documentKey, selectionLines)) {
+			return "editor.unfold";
+		}
+
+		return "editor.fold";
 	}
 
 	return "editor.fold";
@@ -76,31 +147,34 @@ function getFoldCommand(args: CollapseArgs): FoldCommand {
 
 function defaultFoldCommandExecutor(
 	command: FoldCommand,
-	args: { selectionLines: number[] }
+	args: FoldCommandArgs
 ): Thenable<unknown> {
-	if(command === "editor.toggleFold") {
-		return executeToggleFold(args.selectionLines);
-	}
-
 	return vscode.commands.executeCommand(command, args);
 }
 
-async function executeToggleFold(selectionLines: readonly number[]): Promise<unknown> {
+function updateTrackedFoldState(
+	command: FoldCommand,
+	selectionLines: readonly number[],
+	foldState: TrackedFoldState,
+	documentKey: string
+): void {
+	if(command === "editor.fold") {
+		foldState.markCollapsed(documentKey, selectionLines);
+
+		return;
+	}
+
+	foldState.markExpanded(documentKey, selectionLines);
+}
+
+function getActiveDocumentKey(): string {
 	const editor = vscode.window.activeTextEditor;
 
 	if(!editor) {
-		return undefined;
+		return "";
 	}
 
-	const previousSelections = editor.selections;
-
-	editor.selections = selectionLines.map((line) => {
-		return new vscode.Selection(line, 0, line, 0);
-	});
-
-	try {
-		return await vscode.commands.executeCommand("editor.toggleFold");
-	} finally {
-		editor.selections = previousSelections;
-	}
+	return editor.document.uri.toString();
 }
+
+const defaultFoldState = new TrackedFoldState();

--- a/src/engine/regionCollector.ts
+++ b/src/engine/regionCollector.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { RegionNode } from "../model/region";
 import { normalizeSymbols } from "./symbolNormaliser";
+import { getCachedRegions, setCachedRegions } from "../util/cache";
 
 type SymbolProviderResult =
 	| vscode.DocumentSymbol[]
@@ -15,8 +16,22 @@ export async function getRegions(
 	executeSymbolProvider: SymbolProviderExecutor = defaultSymbolProviderExecutor
 ): Promise<RegionNode[]> {
 	try {
+		const uri = document.uri.toString();
+		const cached = getCachedRegions(uri);
+		
+		if(cached && cached.documentVersion === document.version) {
+			return cached.nodes;
+		}
+
 		const symbols = await executeSymbolProvider(document.uri);
-		return normalizeSymbols(symbols);
+		const nodes = normalizeSymbols(symbols);
+		
+		setCachedRegions(uri, {
+			documentVersion: document.version,
+			nodes
+		});
+
+		return nodes;
 	} catch {
 		return [];
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,12 @@
 import * as vscode from "vscode";
-import { collapseCommand, toggleMethodsInClassesCommand } from "./commands/collapse";
+import {
+	collapseCommand,
+	toggleClassMembersCommand,
+	toggleFunctionsInVariablesCommand,
+	toggleMethodsInClassesCommand,
+	toggleTypesCommand,
+	toggleVariablesCommand,
+} from "./commands/collapse";
 import { expandCommand } from "./commands/expand";
 import { toggleCommand } from "./commands/toggle";
 
@@ -11,6 +18,22 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand(
 			"semanticFold.toggleMethodsInClasses",
 			toggleMethodsInClassesCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleClassMembers",
+			toggleClassMembersCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleTypes",
+			toggleTypesCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleVariables",
+			toggleVariablesCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleFunctionsInVariables",
+			toggleFunctionsInVariablesCommand
 		)
 	);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,6 +9,9 @@ import {
 } from "./commands/collapse";
 import { expandCommand } from "./commands/expand";
 import { toggleCommand } from "./commands/toggle";
+import { invalidateRegionCache, invalidateRegionCacheDebounced } from "./util/cache";
+
+const DEBOUNCE_DELAY_MS = 500;
 
 export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
@@ -34,7 +37,16 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand(
 			"semanticFold.toggleFunctionsInVariables",
 			toggleFunctionsInVariablesCommand
-		)
+		),
+		// Register cache invalidation listeners
+		vscode.workspace.onDidChangeTextDocument((event) => {
+			const documentUri = event.document.uri.toString();
+			invalidateRegionCacheDebounced(documentUri, DEBOUNCE_DELAY_MS);
+		}),
+		vscode.workspace.onDidCloseTextDocument((document) => {
+			const documentUri = document.uri.toString();
+			invalidateRegionCache(documentUri);
+		})
 	);
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,13 @@
 import * as vscode from "vscode";
 import { collapseCommand, toggleMethodsInClassesCommand } from "./commands/collapse";
 import { expandCommand } from "./commands/expand";
+import { toggleCommand } from "./commands/toggle";
 
 export function activate(context: vscode.ExtensionContext): void {
 	context.subscriptions.push(
 		vscode.commands.registerCommand("semanticFold.collapse", collapseCommand),
 		vscode.commands.registerCommand("semanticFold.expand", expandCommand),
+		vscode.commands.registerCommand("semanticFold.toggle", toggleCommand),
 		vscode.commands.registerCommand(
 			"semanticFold.toggleMethodsInClasses",
 			toggleMethodsInClassesCommand

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,16 @@
 import * as vscode from "vscode";
-import { collapseCommand } from "./commands/collapse";
+import { collapseCommand, toggleMethodsInClassesCommand } from "./commands/collapse";
 import { expandCommand } from "./commands/expand";
 
 export function activate(context: vscode.ExtensionContext): void {
-    context.subscriptions.push(
-    	vscode.commands.registerCommand("semanticFold.collapse", collapseCommand),
-        vscode.commands.registerCommand("semanticFold.expand", expandCommand)
-    );
+	context.subscriptions.push(
+		vscode.commands.registerCommand("semanticFold.collapse", collapseCommand),
+		vscode.commands.registerCommand("semanticFold.expand", expandCommand),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleMethodsInClasses",
+			toggleMethodsInClassesCommand
+		)
+	);
 }
 
 export function deactivate(): void {}

--- a/src/model/region.ts
+++ b/src/model/region.ts
@@ -1,5 +1,6 @@
 export const REGION_KINDS = [
 	"class",
+	"struct",
 	"interface",
 	"enum",
 	"namespace",
@@ -9,6 +10,7 @@ export const REGION_KINDS = [
 	"property",
 	"field",
 	"variable",
+	"object",
 	"import",
 	"comment",
 	"region",

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDefaultCollapseMode } from "../commands/collapse";
-import { filterRegions, flattenRegions, getAncestors } from "../engine/filterEngine";
+import { filterRegions, flattenRegions, getAncestors, hasHierarchy } from "../engine/filterEngine";
 import {
 	collectFoldableRegions,
 	collectSelectionLines,
@@ -506,6 +506,27 @@ suite("Region Filtering", () => {
 		);
 	});
 
+	test("does not fabricate parent or ancestor matches for flat fallback symbols", () => {
+		const regions = createFlatFallbackFixture();
+		const flatRegions = flattenRegions(regions);
+
+		assert.ok(flatRegions.every((region) => !hasHierarchy(region)));
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			[]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				ancestorKinds: ["class"],
+			}).map((region) => region.name),
+			[]
+		);
+	});
+
 	test("returns regions whose immediate parent kind matches the requested parent kinds", () => {
 		const regions = createPhaseOneFixture();
 
@@ -618,6 +639,24 @@ suite("Region Filtering", () => {
 				ancestorKinds: ["class"],
 			}).map((region) => region.name),
 			["formatPayload"]
+		);
+	});
+
+	test("ignores self-parent links instead of treating them as valid hierarchy", () => {
+		const regions = createFlatFallbackFixture();
+		const runRegion = regions[1];
+
+		runRegion.parent = runRegion;
+
+		assert.strictEqual(hasHierarchy(runRegion), false);
+		assert.deepStrictEqual(getAncestors(runRegion), []);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["method"],
+				ancestorKinds: ["method"],
+			}).map((region) => region.name),
+			[]
 		);
 	});
 });
@@ -763,6 +802,27 @@ suite("Fold Execution Guards", () => {
 				selectionLines: args.selectionLines,
 			});
 		}, foldState, "test://empty");
+
+		assert.deepStrictEqual(executedCommands, []);
+	});
+
+	test("does not execute any command when relationship filters cannot match flat fallback symbols", async () => {
+		const regions = createFlatFallbackFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		await runFoldCommand({
+			filter: {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			},
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://flat-relationship");
 
 		assert.deepStrictEqual(executedCommands, []);
 	});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -7,6 +7,7 @@ import {
 	collectSelectionLines,
 	runFoldCommand,
 	selectFoldableRegions,
+	TrackedFoldState,
 } from "../engine/foldExecutor";
 import { getRegions } from "../engine/regionCollector";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
@@ -545,27 +546,83 @@ suite("Fold Execution Guards", () => {
 	test("executes exact non-recursive fold selection lines", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
 
 		await runFoldCommand({}, regions, async (command, args) => {
-			executedCommands.push({ command, selectionLines: args.selectionLines });
-		});
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://fold");
 
 		assert.deepStrictEqual(executedCommands, [{
 			command: "editor.fold",
+			levels: 1,
 			selectionLines: [2, 6, 12],
 		}]);
 	});
 
-	test("executes exact toggle selection lines for toggle mode", async () => {
+	test("collapses every toggle target when any target is expanded", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
 
 		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
-			executedCommands.push({ command, selectionLines: args.selectionLines });
-		});
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-collapse");
 
 		assert.deepStrictEqual(executedCommands, [{
-			command: "editor.toggleFold",
+			command: "editor.fold",
+			levels: 1,
+			selectionLines: [2, 6, 12],
+		}]);
+	});
+
+	test("expands every toggle target when all targets are collapsed", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		foldState.markCollapsed("test://toggle-expand", [2, 6, 12]);
+
+		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-expand");
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.unfold",
+			levels: 1,
+			selectionLines: [2, 6, 12],
+		}]);
+	});
+
+	test("collapses every toggle target when tracked target state is mixed", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		foldState.markCollapsed("test://toggle-mixed", [2]);
+
+		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-mixed");
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.fold",
+			levels: 1,
 			selectionLines: [2, 6, 12],
 		}]);
 	});
@@ -573,14 +630,19 @@ suite("Fold Execution Guards", () => {
 	test("does not execute any command when no filtered nodes are foldable", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
 
 		await runFoldCommand({
 			filter: {
 				kinds: ["property"],
 			},
 		}, regions, async (command, args) => {
-			executedCommands.push({ command, selectionLines: args.selectionLines });
-		});
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://empty");
 
 		assert.deepStrictEqual(executedCommands, []);
 	});
@@ -588,13 +650,19 @@ suite("Fold Execution Guards", () => {
 	test("executes exact unfold selection lines for expand mode", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
 
 		await runFoldCommand({ mode: "expand" }, regions, async (command, args) => {
-			executedCommands.push({ command, selectionLines: args.selectionLines });
-		});
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://expand");
 
 		assert.deepStrictEqual(executedCommands, [{
 			command: "editor.unfold",
+			levels: 1,
 			selectionLines: [2, 6, 12],
 		}]);
 	});
@@ -717,7 +785,8 @@ function createDuplicateSelectionFixture(): ReturnType<typeof normalizeSymbols> 
 }
 
 interface ExecutedCommand {
-	command: "editor.fold" | "editor.unfold" | "editor.toggleFold";
+	command: "editor.fold" | "editor.unfold";
+	levels: number;
 	selectionLines: number[];
 }
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -22,6 +22,7 @@ suite("Semantic Fold Foundation", () => {
 
 		assert.ok(commands.includes("semanticFold.collapse"));
 		assert.ok(commands.includes("semanticFold.expand"));
+		assert.ok(commands.includes("semanticFold.toggleMethodsInClasses"));
 	});
 });
 
@@ -188,6 +189,7 @@ suite("Command Argument Normalisation", () => {
 					excludeKinds: ["unknown"],
 					exactSymbolDepth: 2,
 					minSymbolDepth: 1,
+					parentKinds: ["class"],
 					nameRegex: "^handle",
 				},
 				preserveCursorContext: true,
@@ -198,6 +200,7 @@ suite("Command Argument Normalisation", () => {
 					excludeKinds: ["unknown"],
 					exactSymbolDepth: 2,
 					minSymbolDepth: 1,
+					parentKinds: ["class"],
 					nameRegex: "^handle",
 				},
 				mode: "collapse",
@@ -498,6 +501,62 @@ suite("Region Filtering", () => {
 		assert.deepStrictEqual(
 			filterRegions(regions, { exactSymbolDepth: 2 }).map((region) => region.name),
 			[]
+		);
+	});
+
+	test("returns regions whose immediate parent kind matches the requested parent kinds", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, { parentKinds: ["class"] }).map((region) => region.name),
+			["constructor", "handle", "ViewModel", "render"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["handle", "render"]
+		);
+	});
+
+	test("keeps top-level helpers visible when filtering methods inside classes", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["handle", "render"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			[]
+		);
+	});
+
+	test("combines parent-kind filters with kind and symbol-depth filters", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+				exactSymbolDepth: 2,
+			}).map((region) => region.name),
+			["handle"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+				exactSymbolDepth: 3,
+			}).map((region) => region.name),
+			["render"]
 		);
 	});
 });

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -85,6 +85,61 @@ suite("Document Symbol Collection", () => {
 		assert.strictEqual(regions[0].name, "helper");
 		assert.strictEqual(regions[0].source, "symbolInformation");
 	});
+
+	test("caches regions per document URI and version", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "class Example {\n\tmethod() {}\n}\n",
+			language: "typescript",
+		});
+		const expectedSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 2);
+		let providerCallCount = 0;
+
+		const regions1 = await getRegions(document, async () => {
+			providerCallCount++;
+			return [expectedSymbol];
+		});
+
+		const regions2 = await getRegions(document, async () => {
+			providerCallCount++;
+			return [expectedSymbol];
+		});
+
+		// Should only call provider once (cache hit on second call)
+		assert.strictEqual(providerCallCount, 1);
+		assert.strictEqual(regions1.length, 1);
+		assert.strictEqual(regions2.length, 1);
+		assert.strictEqual(regions1[0].name, regions2[0].name);
+	});
+
+	test("invalidates cache on document version change", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "class Example {\n\tmethod() {}\n}\n",
+			language: "typescript",
+		});
+		const expectedSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 2);
+		let providerCallCount = 0;
+
+		const regions1 = await getRegions(document, async () => {
+			providerCallCount++;
+			return [expectedSymbol];
+		});
+
+		// Simulate document version change by editing
+		const editResult = await vscode.workspace.openTextDocument({
+			content: "class Example {\n\tmethod() {}\n\tnewMethod() {}\n}\n",
+			language: "typescript",
+		});
+
+		const regions2 = await getRegions(editResult, async () => {
+			providerCallCount++;
+			return [expectedSymbol];
+		});
+
+		// Should call provider twice (version changed, cache miss)
+		assert.strictEqual(providerCallCount, 2);
+		assert.strictEqual(regions1.length, 1);
+		assert.strictEqual(regions2.length, 1);
+	});
 });
 
 suite("Document Symbol Normalisation", () => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -5,23 +5,24 @@ import { filterRegions, flattenRegions, getAncestors, hasHierarchy } from "../en
 import {
 	collectFoldableRegions,
 	collectSelectionLines,
-	runFoldCommand,
+	execFoldCommand,
 	selectFoldableRegions,
 	TrackedFoldState,
 } from "../engine/foldExecutor";
 import { getRegions } from "../engine/regionCollector";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
-import { normaliseArgs, normaliseCollapseFilter } from "../model/filters";
+import { type CollapseFilter, normaliseArgs, normaliseCollapseFilter } from "../model/filters";
 import { mapSymbolKind } from "../util/symbolKindMap";
 
 suite("Semantic Fold Foundation", () => {
-	test("registers collapse and expand commands", async () => {
+	test("registers collapse, expand, and toggle commands", async () => {
 		await activateExtension();
 
 		const commands = await vscode.commands.getCommands(true);
 
 		assert.ok(commands.includes("semanticFold.collapse"));
 		assert.ok(commands.includes("semanticFold.expand"));
+		assert.ok(commands.includes("semanticFold.toggle"));
 		assert.ok(commands.includes("semanticFold.toggleMethodsInClasses"));
 	});
 });
@@ -707,7 +708,7 @@ suite("Fold Execution Guards", () => {
 		const executedCommands: ExecutedCommand[] = [];
 		const foldState = new TrackedFoldState();
 
-		await runFoldCommand({}, regions, async (command, args) => {
+		await execFoldCommand({}, regions, async (command, args) => {
 			executedCommands.push({
 				command,
 				levels: args.levels,
@@ -727,7 +728,7 @@ suite("Fold Execution Guards", () => {
 		const executedCommands: ExecutedCommand[] = [];
 		const foldState = new TrackedFoldState();
 
-		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+		await execFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
 			executedCommands.push({
 				command,
 				levels: args.levels,
@@ -749,7 +750,7 @@ suite("Fold Execution Guards", () => {
 
 		foldState.markCollapsed("test://toggle-expand", [2, 6, 12]);
 
-		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+		await execFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
 			executedCommands.push({
 				command,
 				levels: args.levels,
@@ -771,7 +772,7 @@ suite("Fold Execution Guards", () => {
 
 		foldState.markCollapsed("test://toggle-mixed", [2]);
 
-		await runFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+		await execFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
 			executedCommands.push({
 				command,
 				levels: args.levels,
@@ -791,7 +792,7 @@ suite("Fold Execution Guards", () => {
 		const executedCommands: ExecutedCommand[] = [];
 		const foldState = new TrackedFoldState();
 
-		await runFoldCommand({
+		await execFoldCommand({
 			filter: {
 				kinds: ["property"],
 			},
@@ -811,7 +812,7 @@ suite("Fold Execution Guards", () => {
 		const executedCommands: ExecutedCommand[] = [];
 		const foldState = new TrackedFoldState();
 
-		await runFoldCommand({
+		await execFoldCommand({
 			filter: {
 				kinds: ["method"],
 				parentKinds: ["class"],
@@ -832,7 +833,7 @@ suite("Fold Execution Guards", () => {
 		const executedCommands: ExecutedCommand[] = [];
 		const foldState = new TrackedFoldState();
 
-		await runFoldCommand({ mode: "expand" }, regions, async (command, args) => {
+		await execFoldCommand({ mode: "expand" }, regions, async (command, args) => {
 			executedCommands.push({
 				command,
 				levels: args.levels,
@@ -845,6 +846,76 @@ suite("Fold Execution Guards", () => {
 			levels: 1,
 			selectionLines: [2, 6, 12],
 		}]);
+	});
+
+	test("uses the same filter model for collapse, expand, and toggle modes", async () => {
+		const regions = createPhaseOneFixture();
+		const sharedFilter: CollapseFilter = {
+			kinds: ["method"],
+			parentKinds: ["class"],
+		};
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+		const modeCases = [
+			{
+				documentKey: "test://shared-collapse",
+				expectedCommand: "editor.fold" as const,
+				mode: "collapse" as const,
+			},
+			{
+				documentKey: "test://shared-expand",
+				expectedCommand: "editor.unfold" as const,
+				mode: "expand" as const,
+			},
+			{
+				documentKey: "test://shared-toggle",
+				expectedCommand: "editor.fold" as const,
+				mode: "toggle" as const,
+			},
+		];
+
+		for(const modeCase of modeCases) {
+			await execFoldCommand({
+				filter: sharedFilter,
+				mode: modeCase.mode,
+			}, regions, async (command, args) => {
+				executedCommands.push({
+					command,
+					levels: args.levels,
+					selectionLines: args.selectionLines,
+				});
+			}, foldState, modeCase.documentKey);
+		}
+
+		assert.deepStrictEqual(executedCommands, modeCases.map((modeCase) => ({
+			command: modeCase.expectedCommand,
+			levels: 1,
+			selectionLines: [5, 21],
+		})));
+	});
+
+	test("handles no-match filters cleanly for every fold mode", async () => {
+		const regions = createPhaseOneFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+		const modes = ["collapse", "expand", "toggle"] as const;
+
+		for(const mode of modes) {
+			await execFoldCommand({
+				filter: {
+					kinds: ["import"],
+				},
+				mode,
+			}, regions, async (command, args) => {
+				executedCommands.push({
+					command,
+					levels: args.levels,
+					selectionLines: args.selectionLines,
+				});
+			}, foldState, `test://no-match-${mode}`);
+		}
+
+		assert.deepStrictEqual(executedCommands, []);
 	});
 
 	test("selects foldable regions from flat fallback symbols", () => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -24,6 +24,10 @@ suite("Semantic Fold Foundation", () => {
 		assert.ok(commands.includes("semanticFold.expand"));
 		assert.ok(commands.includes("semanticFold.toggle"));
 		assert.ok(commands.includes("semanticFold.toggleMethodsInClasses"));
+		assert.ok(commands.includes("semanticFold.toggleClassMembers"));
+		assert.ok(commands.includes("semanticFold.toggleTypes"));
+		assert.ok(commands.includes("semanticFold.toggleVariables"));
+		assert.ok(commands.includes("semanticFold.toggleFunctionsInVariables"));
 	});
 });
 
@@ -149,11 +153,13 @@ suite("Document Symbol Normalisation", () => {
 
 suite("Symbol Kind Mapping", () => {
 	test("keeps callable and member symbol kinds distinct", () => {
+		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Struct), "struct");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Function), "function");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Method), "method");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Constructor), "constructor");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Field), "field");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Property), "property");
+		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Object), "object");
 	});
 
 	test("preserves provider-exposed callable and member categories during normalisation", () => {
@@ -623,6 +629,71 @@ suite("Region Filtering", () => {
 		);
 	});
 
+	test("matches convenience command filters for common structural workflows", () => {
+		const regions = createConvenienceCommandFixture();
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["method"],
+					parentKinds: ["class"],
+				},
+			}, regions)),
+			[5, 21]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["constructor", "method", "property", "field"],
+					parentKinds: ["class"],
+				},
+			}, regions)),
+			[1, 5, 21]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["function"],
+					ancestorKinds: ["class"],
+				},
+			}, regions)),
+			[7]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["struct"],
+				},
+			}, regions)),
+			[40]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["class", "struct", "interface", "enum"],
+				},
+			}, regions)),
+			[0, 18, 40, 50, 60]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["variable", "object"],
+				},
+			}, regions)),
+			[70, 86]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["function", "method"],
+					ancestorKinds: ["variable", "object"],
+				},
+			}, regions)),
+			[72, 78, 88]
+		);
+	});
+
 	test("walks ancestor chains safely when a malformed tree has a parent cycle", () => {
 		const regions = createPhaseOneFixture();
 		const controllerRegion = regions[0];
@@ -993,6 +1064,40 @@ function createPhaseOneFixture(): ReturnType<typeof normalizeSymbols> {
 	controllerSymbol.children.push(constructorSymbol, handleSymbol, viewModelSymbol);
 
 	return normalizeSymbols([controllerSymbol, bootstrapSymbol]);
+}
+
+function createConvenienceCommandFixture(): ReturnType<typeof normalizeSymbols> {
+	const controllerSymbol = createSymbol("Controller", vscode.SymbolKind.Class, 0, 28);
+	const constructorSymbol = createSymbol("constructor", vscode.SymbolKind.Constructor, 1, 3);
+	const handleSymbol = createSymbol("handle", vscode.SymbolKind.Method, 5, 16);
+	const formatPayloadSymbol = createSymbol("formatPayload", vscode.SymbolKind.Function, 7, 10);
+	const viewModelSymbol = createSymbol("ViewModel", vscode.SymbolKind.Class, 18, 25);
+	const renderSymbol = createSymbol("render", vscode.SymbolKind.Method, 21, 24);
+	const bootstrapSymbol = createSymbol("bootstrap", vscode.SymbolKind.Function, 32, 36);
+	const dataStructSymbol = createSymbol("DataRecord", vscode.SymbolKind.Struct, 40, 48);
+	const apiInterfaceSymbol = createSymbol("ApiClient", vscode.SymbolKind.Interface, 50, 58);
+	const statusEnumSymbol = createSymbol("Status", vscode.SymbolKind.Enum, 60, 68);
+	const dbVariableSymbol = createSymbol("db", vscode.SymbolKind.Variable, 70, 84);
+	const connectSymbol = createSymbol("connect", vscode.SymbolKind.Method, 72, 76);
+	const buildQuerySymbol = createSymbol("buildQuery", vscode.SymbolKind.Function, 78, 82);
+	const cacheObjectSymbol = createSymbol("cache", vscode.SymbolKind.Object, 86, 96);
+	const hydrateSymbol = createSymbol("hydrate", vscode.SymbolKind.Method, 88, 92);
+
+	handleSymbol.children.push(formatPayloadSymbol);
+	viewModelSymbol.children.push(renderSymbol);
+	controllerSymbol.children.push(constructorSymbol, handleSymbol, viewModelSymbol);
+	dbVariableSymbol.children.push(connectSymbol, buildQuerySymbol);
+	cacheObjectSymbol.children.push(hydrateSymbol);
+
+	return normalizeSymbols([
+		controllerSymbol,
+		bootstrapSymbol,
+		dataStructSymbol,
+		apiInterfaceSymbol,
+		statusEnumSymbol,
+		dbVariableSymbol,
+		cacheObjectSymbol,
+	]);
 }
 
 function createDepthFilterFixture(): ReturnType<typeof normalizeSymbols> {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -281,8 +281,73 @@ suite("Command Argument Normalisation", () => {
 	});
 });
 
+suite("Phase 1 Validation Fixtures", () => {
+	test("models nested classes, methods, and functions in document-symbol order", () => {
+		const regions = createPhaseOneFixture();
+		const flattenedRegions = flattenRegions(regions);
+
+		assert.deepStrictEqual(
+			flattenedRegions.map((region) => `${region.name}:${region.kind}:${region.symbolDepth}`),
+			[
+				"Controller:class:1",
+				"constructor:constructor:2",
+				"handle:method:2",
+				"formatPayload:function:3",
+				"ViewModel:class:2",
+				"render:method:3",
+				"bootstrap:function:1",
+			]
+		);
+	});
+
+	test("matches documented Phase 1 command filters against the nested fixture", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				exactSymbolDepth: 2,
+			}).map((region) => region.name),
+			["handle"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["class", "function"],
+				exactSymbolDepth: 1,
+			}).map((region) => region.name),
+			["Controller", "bootstrap"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method", "function"],
+				minSymbolDepth: 2,
+			}).map((region) => region.name),
+			["handle", "formatPayload", "render"]
+		);
+	});
+
+	test("collects exact method fold targets without recursive child function lines", () => {
+		const regions = createPhaseOneFixture();
+		const foldableRegions = selectFoldableRegions({
+			filter: {
+				kinds: ["method"],
+				minSymbolDepth: 2,
+			},
+		}, regions);
+
+		assert.deepStrictEqual(
+			foldableRegions.map((region) => region.name),
+			["handle", "render"]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(foldableRegions),
+			[5, 21]
+		);
+	});
+});
+
 suite("Region Filtering", () => {
-	test("flattens normalized region trees in document order", () => {
+	test("flattens normalised region trees in document order", () => {
 		const regions = createFilterFixture();
 
 		assert.deepStrictEqual(
@@ -593,6 +658,22 @@ function createFilterFixture(): ReturnType<typeof normalizeSymbols> {
 	classSymbol.children.push(constructorSymbol, fieldSymbol, propertySymbol, methodSymbol);
 
 	return normalizeSymbols([classSymbol, functionSymbol, unknownSymbol]);
+}
+
+function createPhaseOneFixture(): ReturnType<typeof normalizeSymbols> {
+	const controllerSymbol = createSymbol("Controller", vscode.SymbolKind.Class, 0, 28);
+	const constructorSymbol = createSymbol("constructor", vscode.SymbolKind.Constructor, 1, 3);
+	const handleSymbol = createSymbol("handle", vscode.SymbolKind.Method, 5, 16);
+	const formatPayloadSymbol = createSymbol("formatPayload", vscode.SymbolKind.Function, 7, 10);
+	const viewModelSymbol = createSymbol("ViewModel", vscode.SymbolKind.Class, 18, 25);
+	const renderSymbol = createSymbol("render", vscode.SymbolKind.Method, 21, 24);
+	const bootstrapSymbol = createSymbol("bootstrap", vscode.SymbolKind.Function, 30, 35);
+
+	handleSymbol.children.push(formatPayloadSymbol);
+	viewModelSymbol.children.push(renderSymbol);
+	controllerSymbol.children.push(constructorSymbol, handleSymbol, viewModelSymbol);
+
+	return normalizeSymbols([controllerSymbol, bootstrapSymbol]);
 }
 
 function createDepthFilterFixture(): ReturnType<typeof normalizeSymbols> {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,7 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDefaultCollapseMode } from "../commands/collapse";
-import { filterRegions, flattenRegions } from "../engine/filterEngine";
+import { filterRegions, flattenRegions, getAncestors } from "../engine/filterEngine";
 import {
 	collectFoldableRegions,
 	collectSelectionLines,
@@ -189,6 +189,7 @@ suite("Command Argument Normalisation", () => {
 					excludeKinds: ["unknown"],
 					exactSymbolDepth: 2,
 					minSymbolDepth: 1,
+					ancestorKinds: ["class"],
 					parentKinds: ["class"],
 					nameRegex: "^handle",
 				},
@@ -200,6 +201,7 @@ suite("Command Argument Normalisation", () => {
 					excludeKinds: ["unknown"],
 					exactSymbolDepth: 2,
 					minSymbolDepth: 1,
+					ancestorKinds: ["class"],
 					parentKinds: ["class"],
 					nameRegex: "^handle",
 				},
@@ -557,6 +559,65 @@ suite("Region Filtering", () => {
 				exactSymbolDepth: 3,
 			}).map((region) => region.name),
 			["render"]
+		);
+	});
+
+	test("returns regions whose broader ancestor context matches requested kinds", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, { ancestorKinds: ["class"] }).map((region) => region.name),
+			["constructor", "handle", "formatPayload", "ViewModel", "render"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				ancestorKinds: ["class"],
+			}).map((region) => region.name),
+			["formatPayload"]
+		);
+	});
+
+	test("combines ancestor filters with kind, depth, and parent filters", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+				ancestorKinds: ["class"],
+				exactSymbolDepth: 3,
+			}).map((region) => region.name),
+			["render"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				parentKinds: ["method"],
+				ancestorKinds: ["class"],
+				exactSymbolDepth: 3,
+			}).map((region) => region.name),
+			["formatPayload"]
+		);
+	});
+
+	test("walks ancestor chains safely when a malformed tree has a parent cycle", () => {
+		const regions = createPhaseOneFixture();
+		const controllerRegion = regions[0];
+		const handleRegion = controllerRegion.children[1];
+
+		controllerRegion.parent = handleRegion;
+
+		assert.deepStrictEqual(
+			getAncestors(handleRegion).map((region) => region.name),
+			["Controller", "handle"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				ancestorKinds: ["class"],
+			}).map((region) => region.name),
+			["formatPayload"]
 		);
 	});
 });

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -6,19 +6,51 @@ export interface CachedRegions {
 }
 
 const regionCache = new Map<string, CachedRegions>();
+const debounceTimers = new Map<string, NodeJS.Timeout>();
 
 export function getCachedRegions(documentUri: string): CachedRegions | undefined {
-	return regionCache.get(documentUri);
+	const cached = regionCache.get(documentUri);
+	if(cached) {
+		console.debug(`[semanticFold] Cache hit for ${documentUri}`);
+	} else {
+		console.debug(`[semanticFold] Cache miss for ${documentUri}`);
+	}
+	return cached;
 }
 
 export function setCachedRegions(documentUri: string, value: CachedRegions): void {
+	console.debug(`[semanticFold] Setting cache for ${documentUri} at version ${value.documentVersion}`);
 	regionCache.set(documentUri, value);
 }
 
 export function invalidateRegionCache(documentUri: string): void {
+	console.debug(`[semanticFold] Invalidating cache for ${documentUri}`);
 	regionCache.delete(documentUri);
 }
 
+export function invalidateRegionCacheDebounced(documentUri: string, delayMs: number): void {
+	const existingTimer = debounceTimers.get(documentUri);
+	if(existingTimer) {
+		clearTimeout(existingTimer);
+		console.debug(`[semanticFold] Rescheduling debounce for ${documentUri}`);
+	} else {
+		console.debug(`[semanticFold] Scheduled debounce for ${documentUri} in ${delayMs}ms`);
+	}
+
+	const timer = setTimeout(() => {
+		console.debug(`[semanticFold] Debounce fired, invalidating cache for ${documentUri}`);
+		debounceTimers.delete(documentUri);
+		invalidateRegionCache(documentUri);
+	}, delayMs);
+
+	debounceTimers.set(documentUri, timer);
+}
+
 export function clearRegionCache(): void {
+	console.debug(`[semanticFold] Clearing entire region cache`);
 	regionCache.clear();
+	debounceTimers.forEach((timer) => {
+		clearTimeout(timer);
+	});
+	debounceTimers.clear();
 }

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -1,0 +1,24 @@
+import type { RegionNode } from "../model/region";
+
+export interface CachedRegions {
+	documentVersion: number;
+	nodes: RegionNode[];
+}
+
+const regionCache = new Map<string, CachedRegions>();
+
+export function getCachedRegions(documentUri: string): CachedRegions | undefined {
+	return regionCache.get(documentUri);
+}
+
+export function setCachedRegions(documentUri: string, value: CachedRegions): void {
+	regionCache.set(documentUri, value);
+}
+
+export function invalidateRegionCache(documentUri: string): void {
+	regionCache.delete(documentUri);
+}
+
+export function clearRegionCache(): void {
+	regionCache.clear();
+}

--- a/src/util/symbolKindMap.ts
+++ b/src/util/symbolKindMap.ts
@@ -5,6 +5,8 @@ export function mapSymbolKind(kind: vscode.SymbolKind): RegionKind {
 	switch (kind) {
 	case vscode.SymbolKind.Class:
 		return "class";
+	case vscode.SymbolKind.Struct:
+		return "struct";
 	case vscode.SymbolKind.Interface:
 		return "interface";
 	case vscode.SymbolKind.Enum:
@@ -25,6 +27,8 @@ export function mapSymbolKind(kind: vscode.SymbolKind): RegionKind {
 	case vscode.SymbolKind.Variable:
 	case vscode.SymbolKind.Constant:
 		return "variable";
+	case vscode.SymbolKind.Object:
+		return "object";
 	default:
 		return "unknown";
 	}


### PR DESCRIPTION
- Track semantic fold state per document.
- Collapse mixed toggle targets together before expanding as a group.
- Apply parentKinds as an immediate parent filter.
- Add safe ancestor traversal for region nodes.
- Contribute semanticFold.toggle alongside collapse and expand.
- Route fold commands through one shared filtered execution path.
- Add convenience toggles for class members and class-scoped functions.
- Add provider-backed struct, type, variable, and variable-function toggles.
- Per document cache.

Closes #5 #6
Closes #23 #24 #25
Closes #26 #27 #28