### PR TITLE
Phase 3 - Structural Refinement

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,8 @@ The `preserveCursorContext` field is accepted for payload compatibility, but Pha
 
 Toggle state is tracked for folds created through Semantic Fold commands. Manual folding, unfolding, or other extensions can make the tracked state incomplete, but the next semantic toggle collapses a mixed target set back into a consistent state before later toggles expand it as a group.
 
+Category support depends on the active language and folding providers. If the current editor does not report a category such as `import`, `comment`, or `region`, filters for that category simply produce no matching fold targets; other reported categories continue to work.
+
 ## Convenience commands
 
 These commands are available from the Command Palette and use the same filter pipeline as the generic commands:
@@ -400,7 +402,9 @@ That means:
 - some languages may expose great symbol trees
 - some may expose weak or incomplete symbol data
 - semantic token coverage may vary
-- comment/import folding may depend on folding providers
+- import, comment, and region-marker folding may depend on folding providers
+
+Folding-range categories are provider-dependent. A language can report imports without comments, comments without region markers, or none of those categories. Semantic Fold treats missing categories as soft no-match cases instead of errors, so unsupported filters leave the editor unchanged while unrelated supported categories still fold normally.
 
 ### Flat symbol fallback
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,35 @@ Toggle region markers:
 }
 ```
 
+Toggle a file overview that includes imports and top-level types:
+
+```json
+{
+  "key": "ctrl+alt+shift+o",
+  "command": "semanticFold.toggle",
+  "args": {
+    "filter": {
+      "kinds": ["import", "class", "struct", "interface", "enum"],
+      "exactSymbolDepth": 1
+    }
+  }
+}
+```
+
+Toggle comments and methods together:
+
+```json
+{
+  "key": "ctrl+alt+shift+c",
+  "command": "semanticFold.toggle",
+  "args": {
+    "filter": {
+      "kinds": ["comment", "method"]
+    }
+  }
+}
+```
+
 ## Phase 1 Validation
 
 Phase 1 is the symbol-driven MVP. It proves that Semantic Fold can collect document symbols, convert them into one internal region model, filter those regions by kind and symbol depth, and apply folding only to the exact matching regions.
@@ -327,6 +356,7 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Use `filter.kinds: ["import"]`; confirm provider-exposed import folding ranges toggle together.
 - Use `filter.kinds: ["comment"]`; confirm provider-exposed comment block folding ranges toggle together.
 - Use `filter.kinds: ["region"]`; confirm provider-exposed region marker folding ranges toggle together.
+- Use `filter.kinds: ["import", "class", "comment"]`; confirm symbol and folding-range categories toggle together.
 - Use a filter with no matches; confirm the command leaves the editor unchanged.
 
 ### Targeted Folding Versus Recursive Folding

--- a/README.md
+++ b/README.md
@@ -260,6 +260,34 @@ The generic command equivalent is:
 }
 ```
 
+Toggle comment blocks:
+
+```json
+{
+  "key": "ctrl+alt+c",
+  "command": "semanticFold.toggle",
+  "args": {
+    "filter": {
+      "kinds": ["comment"]
+    }
+  }
+}
+```
+
+Toggle region markers:
+
+```json
+{
+  "key": "ctrl+alt+r",
+  "command": "semanticFold.toggle",
+  "args": {
+    "filter": {
+      "kinds": ["region"]
+    }
+  }
+}
+```
+
 ## Phase 1 Validation
 
 Phase 1 is the symbol-driven MVP. It proves that Semantic Fold can collect document symbols, convert them into one internal region model, filter those regions by kind and symbol depth, and apply folding only to the exact matching regions.
@@ -295,6 +323,8 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
 - Run `semanticFold.toggle` with the same filter; confirm it targets the same methods as collapse and expand.
 - Use `filter.kinds: ["import"]`; confirm provider-exposed import folding ranges toggle together.
+- Use `filter.kinds: ["comment"]`; confirm provider-exposed comment block folding ranges toggle together.
+- Use `filter.kinds: ["region"]`; confirm provider-exposed region marker folding ranges toggle together.
 - Use a filter with no matches; confirm the command leaves the editor unchanged.
 
 ### Targeted Folding Versus Recursive Folding
@@ -468,7 +498,7 @@ Open the workspace in VS Code and launch the extension host from the debugger.
 - [x] Add keybinding-ready generic command
 - [ ] Add convenience commands
 - [x] Add imports support
-- [ ] Add comments/regions support
+- [x] Add comments/regions support
 - [ ] Add semantic-token refinement
 - [ ] Add presets
 - [ ] Publish extension

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ These commands are available from the Command Palette and use the same filter pi
 | `semanticFold.toggleTypes` | Toggle provider-exposed class, struct, interface, and enum regions. Type aliases are included only if the language provider reports them as one of those symbol kinds. |
 | `semanticFold.toggleVariables` | Toggle variable, constant, and object regions that have foldable symbol ranges. |
 | `semanticFold.toggleFunctionsInVariables` | Toggle function and method regions anywhere inside a variable or object ancestor context, such as functions inside an object literal assigned to a variable. |
+| `semanticFold.toggleImports` | Toggle provider-exposed import folding ranges. |
 
 Toggle methods whose immediate parent is a class:
 
@@ -236,6 +237,29 @@ Toggle implementation details below the top level:
 }
 ```
 
+Toggle imports:
+
+```json
+{
+  "key": "ctrl+alt+p",
+  "command": "semanticFold.toggleImports"
+}
+```
+
+The generic command equivalent is:
+
+```json
+{
+  "key": "ctrl+alt+p",
+  "command": "semanticFold.toggle",
+  "args": {
+    "filter": {
+      "kinds": ["import"]
+    }
+  }
+}
+```
+
 ## Phase 1 Validation
 
 Phase 1 is the symbol-driven MVP. It proves that Semantic Fold can collect document symbols, convert them into one internal region model, filter those regions by kind and symbol depth, and apply folding only to the exact matching regions.
@@ -266,9 +290,11 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Run `semanticFold.toggleTypes`; confirm class, struct, interface, and enum regions toggle.
 - Run `semanticFold.toggleVariables`; confirm foldable variable, constant, and object regions toggle.
 - Run `semanticFold.toggleFunctionsInVariables`; confirm function and method regions inside variable or object contexts toggle when the provider exposes that hierarchy.
+- Run `semanticFold.toggleImports`; confirm provider-exposed import folding ranges toggle together.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
 - Run `semanticFold.toggle` with the same filter; confirm it targets the same methods as collapse and expand.
+- Use `filter.kinds: ["import"]`; confirm provider-exposed import folding ranges toggle together.
 - Use a filter with no matches; confirm the command leaves the editor unchanged.
 
 ### Targeted Folding Versus Recursive Folding
@@ -441,7 +467,8 @@ Open the workspace in VS Code and launch the extension host from the debugger.
 - [x] Add targeted collapse execution
 - [x] Add keybinding-ready generic command
 - [ ] Add convenience commands
-- [ ] Add imports/comments/regions support
+- [x] Add imports support
+- [ ] Add comments/regions support
 - [ ] Add semantic-token refinement
 - [ ] Add presets
 - [ ] Publish extension

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semantic-fold",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semantic-fold",
-      "version": "0.1.0",
+      "version": "0.1.1",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semantic-fold",
-  "version": "0.1.1",
+  "version": "0.1.2-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semantic-fold",
-      "version": "0.1.1",
+      "version": "0.1.2-dev",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "semantic-fold",
   "displayName": "Semantic Fold",
   "description": "Policy-driven code folding for VS Code",
-  "version": "0.1.1",
+  "version": "0.1.2-dev",
   "engines": {
     "vscode": "^1.111.0"
   },
@@ -47,6 +47,10 @@
       {
         "command": "semanticFold.toggleFunctionsInVariables",
         "title": "Semantic Fold: Toggle Functions in Variables"
+      },
+      {
+        "command": "semanticFold.toggleImports",
+        "title": "Semantic Fold: Toggle Imports"
       }
     ]
   },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "semantic-fold",
   "displayName": "Semantic Fold",
   "description": "Policy-driven code folding for VS Code",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "engines": {
     "vscode": "^1.111.0"
   },

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -39,6 +39,13 @@ const functionsInVariablesArgs: CollapseArgs = {
 	mode: "toggle",
 };
 
+const importsArgs: CollapseArgs = {
+	filter: {
+		kinds: ["import"],
+	},
+	mode: "toggle",
+};
+
 export async function collapseCommand(args?: unknown): Promise<void> {
 	await runFoldCommand(args, getDefaultCollapseMode(args));
 }
@@ -61,6 +68,10 @@ export async function toggleVariablesCommand(): Promise<void> {
 
 export async function toggleFunctionsInVariablesCommand(): Promise<void> {
 	await collapseCommand(functionsInVariablesArgs);
+}
+
+export async function toggleImportsCommand(): Promise<void> {
+	await collapseCommand(importsArgs);
 }
 
 export function getDefaultCollapseMode(args: unknown): CollapseArgs["mode"] {

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -1,6 +1,10 @@
 import { type CollapseArgs } from "../model/filters";
 import { runFoldCommand } from "./foldCommand";
 
+/*
+ * Filters for contributed commands, provider-backed categories only
+ */
+
 const methodsInClassesArgs: CollapseArgs = {
 	filter: {
 		kinds: ["method", "function"],
@@ -46,6 +50,9 @@ const importsArgs: CollapseArgs = {
 	mode: "toggle",
 };
 
+/**
+ * Base collapse command used by the command palette and keybinding payloads
+ */
 export async function collapseCommand(args?: unknown): Promise<void> {
 	await runFoldCommand(args, getDefaultCollapseMode(args));
 }
@@ -74,6 +81,10 @@ export async function toggleImportsCommand(): Promise<void> {
 	await collapseCommand(importsArgs);
 }
 
+/**
+ * Plain command-palette collapse defaults to one-way collapse, while structured
+ * payloads default to toggle so keybindings can reuse the same command entry
+ */
 export function getDefaultCollapseMode(args: unknown): CollapseArgs["mode"] {
 	if(isRecord(args)) {
 		return "toggle";
@@ -82,6 +93,9 @@ export function getDefaultCollapseMode(args: unknown): CollapseArgs["mode"] {
 	return "collapse";
 }
 
+/**
+ * Narrows arbitrary command payloads to object-like values
+ */
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }

--- a/src/commands/expand.ts
+++ b/src/commands/expand.ts
@@ -1,5 +1,8 @@
 import { runFoldCommand } from "./foldCommand";
 
+/**
+ * Command-palette entry point for explicit unfold requests
+ */
 export async function expandCommand(args?: unknown): Promise<void> {
 	await runFoldCommand(args, "expand");
 }

--- a/src/commands/foldCommand.ts
+++ b/src/commands/foldCommand.ts
@@ -3,6 +3,12 @@ import { getRegions } from "../engine/regionCollector";
 import { execFoldCommand } from "../engine/foldExecutor";
 import { type CollapseArgs, normaliseArgs } from "../model/filters";
 
+/**
+ * Shared command runner for collapse, expand, toggle, and convenience commands
+ *
+ * The command payload is normalised before execution so command-palette calls
+ * and keybindings pass through the same filter contract
+ */
 export async function runFoldCommand(args: unknown, defaultMode: CollapseArgs["mode"]): Promise<void> {
 	const editor = vscode.window.activeTextEditor;
 

--- a/src/commands/toggle.ts
+++ b/src/commands/toggle.ts
@@ -1,5 +1,8 @@
 import { runFoldCommand } from "./foldCommand";
 
+/**
+ * Command-palette entry point for stateful fold toggling
+ */
 export async function toggleCommand(args?: unknown): Promise<void> {
 	await runFoldCommand(args, "toggle");
 }

--- a/src/engine/filterEngine.ts
+++ b/src/engine/filterEngine.ts
@@ -1,6 +1,9 @@
 import type { CollapseFilter } from "../model/filters";
 import type { RegionNode } from "../model/region";
 
+/**
+ * Returns regions that satisfy every active filter constraint
+ */
 export function filterRegions(rootNodes: readonly RegionNode[], filter: CollapseFilter = {}): RegionNode[] {
 	const regions = flattenRegions(rootNodes);
 
@@ -13,6 +16,9 @@ export function filterRegions(rootNodes: readonly RegionNode[], filter: Collapse
 	});
 }
 
+/**
+ * Flattens a region tree in pre-order document traversal
+ */
 export function flattenRegions(rootNodes: readonly RegionNode[]): RegionNode[] {
 	const regions: RegionNode[] = [];
 
@@ -23,6 +29,9 @@ export function flattenRegions(rootNodes: readonly RegionNode[]): RegionNode[] {
 	return regions;
 }
 
+/**
+ * Appends the current region before its children to preserve provider order
+ */
 function appendRegion(region: RegionNode, regions: RegionNode[]): void {
 	regions.push(region);
 
@@ -31,6 +40,9 @@ function appendRegion(region: RegionNode, regions: RegionNode[]): void {
 	}
 }
 
+/**
+ * Treats an empty include list as a wildcard
+ */
 function matchesIncludedKind(region: RegionNode, filter: CollapseFilter): boolean {
 	if(!filter.kinds || filter.kinds.length === 0) {
 		return true;
@@ -39,6 +51,9 @@ function matchesIncludedKind(region: RegionNode, filter: CollapseFilter): boolea
 	return filter.kinds.includes(region.kind);
 }
 
+/**
+ * Applies exclusions after inclusion matching
+ */
 function matchesExcludedKind(region: RegionNode, filter: CollapseFilter): boolean {
 	if(!filter.excludeKinds || filter.excludeKinds.length === 0) {
 		return false;
@@ -47,6 +62,9 @@ function matchesExcludedKind(region: RegionNode, filter: CollapseFilter): boolea
 	return filter.excludeKinds.includes(region.kind);
 }
 
+/**
+ * Matches against the immediate parent only
+ */
 function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean {
 	if(!filter.parentKinds || filter.parentKinds.length === 0) {
 		return true;
@@ -57,6 +75,9 @@ function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean 
 	return parent !== undefined && filter.parentKinds.includes(parent.kind);
 }
 
+/**
+ * Matches against any valid parent chain ancestor
+ */
 function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolean {
 	if(!filter.ancestorKinds || filter.ancestorKinds.length === 0) {
 		return true;
@@ -65,10 +86,16 @@ function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolea
 	return getAncestors(region).some((ancestor) => filter.ancestorKinds?.includes(ancestor.kind));
 }
 
+/**
+ * Reports whether a node participates in a usable hierarchy
+ */
 export function hasHierarchy(region: RegionNode): boolean {
 	return getParent(region) !== undefined || region.children.length > 0;
 }
 
+/**
+ * Ignores malformed self-parent links instead of treating them as hierarchy
+ */
 function getParent(region: RegionNode): RegionNode | undefined {
 	if(region.parent === region) {
 		return undefined;
@@ -77,6 +104,9 @@ function getParent(region: RegionNode): RegionNode | undefined {
 	return region.parent;
 }
 
+/**
+ * Walks ancestor links with cycle protection for malformed provider data
+ */
 export function getAncestors(region: RegionNode): RegionNode[] {
 	const ancestors: RegionNode[] = [];
 	const visitedNodes = new Set<RegionNode>();
@@ -91,6 +121,9 @@ export function getAncestors(region: RegionNode): RegionNode[] {
 	return ancestors;
 }
 
+/**
+ * Applies symbol-depth constraints independently from kind filters
+ */
 function matchesSymbolDepth(region: RegionNode, filter: CollapseFilter): boolean {
 	if(filter.exactSymbolDepth !== undefined && region.symbolDepth !== filter.exactSymbolDepth) {
 		return false;

--- a/src/engine/foldExecutor.ts
+++ b/src/engine/foldExecutor.ts
@@ -3,21 +3,43 @@ import type { CollapseArgs } from "../model/filters";
 import type { RegionNode } from "../model/region";
 import { filterRegions } from "./filterEngine";
 
+/**
+ * Fold execution owns the last step of the Semantic Fold pipeline:
+ * selecting foldable regions, converting them to editor selection lines, and
+ * dispatching VS Code's built-in fold or unfold command
+ */
 type FoldCommand = "editor.fold" | "editor.unfold";
 
+/**
+ * Shape expected by VS Code's fold commands when folding explicit target lines
+ */
 interface FoldCommandArgs {
 	selectionLines: number[];
 	levels: number;
 }
 
+/**
+ * Injectable command executor used by tests to observe fold requests without
+ * invoking VS Code editor state
+ */
 export type FoldCommandExecutor = (
 	command: FoldCommand,
 	args: FoldCommandArgs
 ) => Thenable<unknown>;
 
+/**
+ * Tracks fold state created by Semantic Fold commands per document so toggle
+ * mode can behave consistently across repeated command runs
+ */
 export class TrackedFoldState {
 	private readonly collapsedLinesByDocument = new Map<string, Set<number>>();
 
+	/**
+	 * Returns true only when every target line is currently tracked as collapsed
+	 *
+	 * Empty targets intentionally return false so toggle mode never turns a
+	 * no-op into an unfold request
+	 */
 	public areAllCollapsed(documentKey: string, selectionLines: readonly number[]): boolean {
 		const collapsedLines = this.collapsedLinesByDocument.get(documentKey);
 
@@ -28,6 +50,9 @@ export class TrackedFoldState {
 		return selectionLines.every((line) => collapsedLines.has(line));
 	}
 
+	/**
+	 * Marks target lines as collapsed after a successful fold command
+	 */
 	public markCollapsed(documentKey: string, selectionLines: readonly number[]): void {
 		const collapsedLines = this.getCollapsedLines(documentKey);
 
@@ -36,6 +61,9 @@ export class TrackedFoldState {
 		}
 	}
 
+	/**
+	 * Marks target lines as expanded and drops empty document entries
+	 */
 	public markExpanded(documentKey: string, selectionLines: readonly number[]): void {
 		const collapsedLines = this.collapsedLinesByDocument.get(documentKey);
 
@@ -52,6 +80,9 @@ export class TrackedFoldState {
 		}
 	}
 
+	/**
+	 * Lazily creates the tracked line set for a document
+	 */
 	private getCollapsedLines(documentKey: string): Set<number> {
 		const existingLines = this.collapsedLinesByDocument.get(documentKey);
 
@@ -67,12 +98,21 @@ export class TrackedFoldState {
 	}
 }
 
+/**
+ * A region is foldable only when it spans more than one line
+ *
+ * VS Code folding operates on ranges with hidden content after the start line,
+ * so zero-span and single-line regions are intentionally ignored
+ */
 export function isFoldableRegion(region: RegionNode): boolean {
 	return Number.isInteger(region.rangeStartLine)
 		&& Number.isInteger(region.rangeEndLine)
 		&& region.rangeEndLine > region.rangeStartLine;
 }
 
+/**
+ * Collects every foldable region from an already-normalised tree
+ */
 export function collectFoldableRegions(rootNodes: readonly RegionNode[]): RegionNode[] {
 	const foldableRegions: RegionNode[] = [];
 
@@ -83,6 +123,9 @@ export function collectFoldableRegions(rootNodes: readonly RegionNode[]): Region
 	return foldableRegions;
 }
 
+/**
+ * Applies the command filter first, then removes nodes VS Code cannot fold
+ */
 export function selectFoldableRegions(
 	args: CollapseArgs,
 	rootNodes: readonly RegionNode[]
@@ -90,11 +133,22 @@ export function selectFoldableRegions(
 	return filterRegions(rootNodes, args.filter).filter(isFoldableRegion);
 }
 
+/**
+ * Converts selected regions into the exact start lines sent to VS Code
+ *
+ * The Set removes duplicated targets from overlapping symbol and folding-range
+ * nodes, while sorting keeps the resulting editor command deterministic
+ */
 export function collectSelectionLines(regions: readonly RegionNode[]): number[] {
 	return [...new Set(regions.map((region) => region.selectionLine))]
 		.sort((left, right) => left - right);
 }
 
+/**
+ * Executes a fold, unfold, or toggle request against the provided region tree
+ *
+ * The default arguments use live VS Code state
+ */
 export async function execFoldCommand(
 	args: CollapseArgs,
 	rootNodes: readonly RegionNode[] = [],
@@ -110,10 +164,14 @@ export async function execFoldCommand(
 
 	const command = getFoldCommand(args, selectionLines, foldState, documentKey);
 
+	// levels: 1 keeps Semantic Fold targeted instead of recursively folding children
 	await executeCommand(command, { selectionLines, levels: 1 });
 	updateTrackedFoldState(command, selectionLines, foldState, documentKey);
 }
 
+/**
+ * Recursive helper for collecting foldable nodes without flattening the tree first
+ */
 function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]): void {
 	if(isFoldableRegion(region)) {
 		foldableRegions.push(region);
@@ -124,6 +182,9 @@ function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]
 	}
 }
 
+/**
+ * Resolves the VS Code command to execute for the requested fold mode
+ */
 function getFoldCommand(
 	args: CollapseArgs,
 	selectionLines: readonly number[],
@@ -145,6 +206,9 @@ function getFoldCommand(
 	return "editor.fold";
 }
 
+/**
+ * Production command bridge to VS Code's editor folding commands
+ */
 function defaultFoldCommandExecutor(
 	command: FoldCommand,
 	args: FoldCommandArgs
@@ -152,6 +216,9 @@ function defaultFoldCommandExecutor(
 	return vscode.commands.executeCommand(command, args);
 }
 
+/**
+ * Mirrors successful command execution into the tracked toggle state
+ */
 function updateTrackedFoldState(
 	command: FoldCommand,
 	selectionLines: readonly number[],
@@ -167,6 +234,9 @@ function updateTrackedFoldState(
 	foldState.markExpanded(documentKey, selectionLines);
 }
 
+/**
+ * Uses the active editor URI as the fold-state key when commands run normally
+ */
 function getActiveDocumentKey(): string {
 	const editor = vscode.window.activeTextEditor;
 
@@ -177,4 +247,7 @@ function getActiveDocumentKey(): string {
 	return editor.document.uri.toString();
 }
 
+/**
+ * Shared state for normal command execution
+ */
 const defaultFoldState = new TrackedFoldState();

--- a/src/engine/foldingRangeRefiner.ts
+++ b/src/engine/foldingRangeRefiner.ts
@@ -38,8 +38,7 @@ export function attachFoldingOnlyNodes(
 
 		if(parent) {
 			foldingNode.parent = parent;
-			foldingNode.symbolDepth = parent.symbolDepth + 1;
-			foldingNode.foldDepth = (parent.foldDepth ?? 0) + 1;
+			updateFoldingNodeDepths(foldingNode, parent.symbolDepth + 1, (parent.foldDepth ?? 0) + 1);
 			parent.children.push(foldingNode);
 			parent.children.sort(compareRegions);
 			continue;
@@ -187,6 +186,18 @@ function isCoveredBySymbolRegion(
 		return rangesOverlap(symbolNode, foldingNode)
 			&& (hasSameRange(symbolNode, foldingNode) || symbolNode.selectionLine === foldingNode.selectionLine);
 	});
+}
+
+/**
+ * Refreshes folding-only descendant depths after a parent attachment changes
+ */
+function updateFoldingNodeDepths(region: RegionNode, symbolDepth: number, foldDepth: number): void {
+	region.symbolDepth = symbolDepth;
+	region.foldDepth = foldDepth;
+
+	for(const child of region.children) {
+		updateFoldingNodeDepths(child, symbolDepth + 1, foldDepth + 1);
+	}
 }
 
 /**

--- a/src/engine/foldingRangeRefiner.ts
+++ b/src/engine/foldingRangeRefiner.ts
@@ -1,9 +1,96 @@
 import * as vscode from "vscode";
-import type { RegionNode } from "../model/region";
+import type { RegionKind, RegionNode } from "../model/region";
+import { mapFoldingRangeKind } from "../util/symbolKindMap";
+
+const supportedFoldingRangeKinds = new Set<RegionKind>(["import"]);
 
 export function attachFoldingOnlyNodes(
-	_rootNodes: RegionNode[],
-  	_foldingRanges: vscode.FoldingRange[]
-): void {
-	return;
+	rootNodes: RegionNode[],
+	foldingRanges: vscode.FoldingRange[] | null | undefined
+): RegionNode[] {
+	const foldingNodes = normaliseFoldingRanges(foldingRanges);
+
+	if(foldingNodes.length === 0) {
+		return [...rootNodes];
+	}
+
+	return [...rootNodes, ...foldingNodes].sort(compareRegions);
+}
+
+export function normaliseFoldingRanges(
+	foldingRanges: vscode.FoldingRange[] | null | undefined
+): RegionNode[] {
+	if(!Array.isArray(foldingRanges)) {
+		return [];
+	}
+
+	return foldingRanges
+		.map((foldingRange, index) => foldingRangeNode(foldingRange, index))
+		.filter((region): region is RegionNode => region !== undefined);
+}
+
+function foldingRangeNode(
+	foldingRange: vscode.FoldingRange,
+	index: number
+): RegionNode | undefined {
+	if(!isValidFoldingRange(foldingRange)) {
+		return undefined;
+	}
+
+	const kind = mapFoldingRangeKind(foldingRange.kind);
+
+	if(!supportedFoldingRangeKinds.has(kind)) {
+		return undefined;
+	}
+
+	return {
+		id: createFoldingRangeNodeId(kind, foldingRange, index),
+		name: kind,
+		kind,
+		rangeStartLine: foldingRange.start,
+		rangeEndLine: foldingRange.end,
+		selectionLine: foldingRange.start,
+		symbolDepth: 1,
+		foldDepth: 1,
+		children: [],
+		source: "foldingRange",
+	};
+}
+
+function createFoldingRangeNodeId(
+	kind: RegionKind,
+	foldingRange: vscode.FoldingRange,
+	path: number
+): string {
+	return [
+		"foldingRange",
+		path,
+		kind,
+		foldingRange.start,
+		foldingRange.end,
+	].join(":");
+}
+
+function compareRegions(left: RegionNode, right: RegionNode): number {
+	if(left.rangeStartLine !== right.rangeStartLine) {
+		return left.rangeStartLine - right.rangeStartLine;
+	}
+
+	if(left.rangeEndLine !== right.rangeEndLine) {
+		return left.rangeEndLine - right.rangeEndLine;
+	}
+
+	return left.id.localeCompare(right.id);
+}
+
+function isValidFoldingRange(value: unknown): value is vscode.FoldingRange {
+	const foldingRange = value as Partial<vscode.FoldingRange>;
+
+	return foldingRange !== undefined
+		&& typeof foldingRange.start === "number"
+		&& Number.isInteger(foldingRange.start)
+		&& foldingRange.start >= 0
+		&& typeof foldingRange.end === "number"
+		&& Number.isInteger(foldingRange.end)
+		&& foldingRange.end >= foldingRange.start;
 }

--- a/src/engine/foldingRangeRefiner.ts
+++ b/src/engine/foldingRangeRefiner.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode";
 import type { RegionKind, RegionNode } from "../model/region";
 import { mapFoldingRangeKind } from "../util/symbolKindMap";
 
-const supportedFoldingRangeKinds = new Set<RegionKind>(["import"]);
+const supportedFoldingRangeKinds = new Set<RegionKind>(["import", "comment", "region"]);
 
 export function attachFoldingOnlyNodes(
 	rootNodes: RegionNode[],

--- a/src/engine/foldingRangeRefiner.ts
+++ b/src/engine/foldingRangeRefiner.ts
@@ -8,13 +8,36 @@ export function attachFoldingOnlyNodes(
 	rootNodes: RegionNode[],
 	foldingRanges: vscode.FoldingRange[] | null | undefined
 ): RegionNode[] {
-	const foldingNodes = normaliseFoldingRanges(foldingRanges);
+	const symbolNodes = flattenRegionTree(rootNodes).filter((region) => {
+		return region.source !== "foldingRange";
+	});
+	const foldingNodes = normaliseFoldingRanges(foldingRanges).filter((foldingNode) => {
+		return !isCoveredBySymbolRegion(foldingNode, symbolNodes);
+	});
 
 	if(foldingNodes.length === 0) {
 		return [...rootNodes];
 	}
 
-	return [...rootNodes, ...foldingNodes].sort(compareRegions);
+	const mergedRootNodes = [...rootNodes];
+	const candidateParents = [...flattenRegionTree(rootNodes), ...foldingNodes];
+
+	for(const foldingNode of foldingNodes) {
+		const parent = findSmallestContainingNode(foldingNode, candidateParents);
+
+		if(parent) {
+			foldingNode.parent = parent;
+			foldingNode.symbolDepth = parent.symbolDepth + 1;
+			foldingNode.foldDepth = (parent.foldDepth ?? 0) + 1;
+			parent.children.push(foldingNode);
+			parent.children.sort(compareRegions);
+			continue;
+		}
+
+		mergedRootNodes.push(foldingNode);
+	}
+
+	return mergedRootNodes.sort(compareRegions);
 }
 
 export function normaliseFoldingRanges(
@@ -81,6 +104,70 @@ function compareRegions(left: RegionNode, right: RegionNode): number {
 	}
 
 	return left.id.localeCompare(right.id);
+}
+
+function findSmallestContainingNode(
+	foldingNode: RegionNode,
+	candidateParents: readonly RegionNode[]
+): RegionNode | undefined {
+	const containingNodes = candidateParents.filter((candidate) => {
+		return candidate !== foldingNode && containsRange(candidate, foldingNode);
+	});
+
+	return containingNodes.sort((left, right) => {
+		const leftSpan = left.rangeEndLine - left.rangeStartLine;
+		const rightSpan = right.rangeEndLine - right.rangeStartLine;
+
+		if(leftSpan !== rightSpan) {
+			return leftSpan - rightSpan;
+		}
+
+		return compareRegions(left, right);
+	})[0];
+}
+
+function flattenRegionTree(rootNodes: readonly RegionNode[]): RegionNode[] {
+	const regions: RegionNode[] = [];
+
+	for(const rootNode of rootNodes) {
+		appendRegion(rootNode, regions);
+	}
+
+	return regions;
+}
+
+function appendRegion(region: RegionNode, regions: RegionNode[]): void {
+	regions.push(region);
+
+	for(const child of region.children) {
+		appendRegion(child, regions);
+	}
+}
+
+function isCoveredBySymbolRegion(
+	foldingNode: RegionNode,
+	symbolNodes: readonly RegionNode[]
+): boolean {
+	return symbolNodes.some((symbolNode) => {
+		return rangesOverlap(symbolNode, foldingNode)
+			&& (hasSameRange(symbolNode, foldingNode) || symbolNode.selectionLine === foldingNode.selectionLine);
+	});
+}
+
+function containsRange(parent: RegionNode, child: RegionNode): boolean {
+	return parent.rangeStartLine <= child.rangeStartLine
+		&& parent.rangeEndLine >= child.rangeEndLine
+		&& !hasSameRange(parent, child);
+}
+
+function hasSameRange(left: RegionNode, right: RegionNode): boolean {
+	return left.rangeStartLine === right.rangeStartLine
+		&& left.rangeEndLine === right.rangeEndLine;
+}
+
+function rangesOverlap(left: RegionNode, right: RegionNode): boolean {
+	return left.rangeStartLine <= right.rangeEndLine
+		&& right.rangeStartLine <= left.rangeEndLine;
 }
 
 function isValidFoldingRange(value: unknown): value is vscode.FoldingRange {

--- a/src/engine/foldingRangeRefiner.ts
+++ b/src/engine/foldingRangeRefiner.ts
@@ -2,8 +2,17 @@ import * as vscode from "vscode";
 import type { RegionKind, RegionNode } from "../model/region";
 import { mapFoldingRangeKind } from "../util/symbolKindMap";
 
+/**
+ * Folding-range categories that VS Code can identify without semantic tokens
+ */
 const supportedFoldingRangeKinds = new Set<RegionKind>(["import", "comment", "region"]);
 
+/**
+ * Merges supported folding-range-only nodes into the symbol region tree
+ *
+ * Symbol-backed regions stay authoritative, while imports, comments, and region
+ * markers fill gaps that document-symbol providers do not normally expose
+ */
 export function attachFoldingOnlyNodes(
 	rootNodes: RegionNode[],
 	foldingRanges: vscode.FoldingRange[] | null | undefined
@@ -20,6 +29,8 @@ export function attachFoldingOnlyNodes(
 	}
 
 	const mergedRootNodes = [...rootNodes];
+
+	// Include folding nodes as candidates so nested folding ranges can parent each other
 	const candidateParents = [...flattenRegionTree(rootNodes), ...foldingNodes];
 
 	for(const foldingNode of foldingNodes) {
@@ -40,6 +51,9 @@ export function attachFoldingOnlyNodes(
 	return mergedRootNodes.sort(compareRegions);
 }
 
+/**
+ * Converts raw VS Code folding ranges into normalised region nodes
+ */
 export function normaliseFoldingRanges(
 	foldingRanges: vscode.FoldingRange[] | null | undefined
 ): RegionNode[] {
@@ -52,6 +66,9 @@ export function normaliseFoldingRanges(
 		.filter((region): region is RegionNode => region !== undefined);
 }
 
+/**
+ * Builds a region node only for valid and supported folding-range categories
+ */
 function foldingRangeNode(
 	foldingRange: vscode.FoldingRange,
 	index: number
@@ -80,6 +97,9 @@ function foldingRangeNode(
 	};
 }
 
+/**
+ * Creates deterministic ids for folding ranges that do not have provider names
+ */
 function createFoldingRangeNodeId(
 	kind: RegionKind,
 	foldingRange: vscode.FoldingRange,
@@ -94,6 +114,9 @@ function createFoldingRangeNodeId(
 	].join(":");
 }
 
+/**
+ * Sorts regions by source order with deterministic tie-breaking
+ */
 function compareRegions(left: RegionNode, right: RegionNode): number {
 	if(left.rangeStartLine !== right.rangeStartLine) {
 		return left.rangeStartLine - right.rangeStartLine;
@@ -106,6 +129,9 @@ function compareRegions(left: RegionNode, right: RegionNode): number {
 	return left.id.localeCompare(right.id);
 }
 
+/**
+ * Finds the tightest parent range so folding-only nodes attach naturally
+ */
 function findSmallestContainingNode(
 	foldingNode: RegionNode,
 	candidateParents: readonly RegionNode[]
@@ -126,6 +152,9 @@ function findSmallestContainingNode(
 	})[0];
 }
 
+/**
+ * Flattens the tree for relationship checks without mutating it
+ */
 function flattenRegionTree(rootNodes: readonly RegionNode[]): RegionNode[] {
 	const regions: RegionNode[] = [];
 
@@ -136,6 +165,9 @@ function flattenRegionTree(rootNodes: readonly RegionNode[]): RegionNode[] {
 	return regions;
 }
 
+/**
+ * Appends the current region before its children to preserve source order
+ */
 function appendRegion(region: RegionNode, regions: RegionNode[]): void {
 	regions.push(region);
 
@@ -144,6 +176,9 @@ function appendRegion(region: RegionNode, regions: RegionNode[]): void {
 	}
 }
 
+/**
+ * Drops folding ranges already represented by a symbol-backed node
+ */
 function isCoveredBySymbolRegion(
 	foldingNode: RegionNode,
 	symbolNodes: readonly RegionNode[]
@@ -154,22 +189,34 @@ function isCoveredBySymbolRegion(
 	});
 }
 
+/**
+ * Checks strict containment so identical ranges do not become parent-child pairs
+ */
 function containsRange(parent: RegionNode, child: RegionNode): boolean {
 	return parent.rangeStartLine <= child.rangeStartLine
 		&& parent.rangeEndLine >= child.rangeEndLine
 		&& !hasSameRange(parent, child);
 }
 
+/**
+ * Checks exact range equality
+ */
 function hasSameRange(left: RegionNode, right: RegionNode): boolean {
 	return left.rangeStartLine === right.rangeStartLine
 		&& left.rangeEndLine === right.rangeEndLine;
 }
 
+/**
+ * Checks whether two inclusive line ranges overlap
+ */
 function rangesOverlap(left: RegionNode, right: RegionNode): boolean {
 	return left.rangeStartLine <= right.rangeEndLine
 		&& right.rangeStartLine <= left.rangeEndLine;
 }
 
+/**
+ * Guards against malformed provider data before normalisation
+ */
 function isValidFoldingRange(value: unknown): value is vscode.FoldingRange {
 	const foldingRange = value as Partial<vscode.FoldingRange>;
 

--- a/src/engine/regionCollector.ts
+++ b/src/engine/regionCollector.ts
@@ -4,6 +4,9 @@ import { getCachedRegions, setCachedRegions } from "../util/cache";
 import { attachFoldingOnlyNodes } from "./foldingRangeRefiner";
 import { normalizeSymbols } from "./symbolNormaliser";
 
+/**
+ * Raw shapes returned by VS Code's document-symbol provider command
+ */
 type SymbolProviderResult =
 	| vscode.DocumentSymbol[]
 	| vscode.SymbolInformation[]
@@ -12,9 +15,19 @@ type SymbolProviderResult =
 
 type FoldingRangeProviderResult = vscode.FoldingRange[] | null | undefined;
 
+/**
+ * Injectable document-symbol provider executor for tests and command isolation
+ */
 export type SymbolProviderExecutor = (uri: vscode.Uri) => Thenable<SymbolProviderResult>;
+
+/**
+ * Injectable folding-range provider executor for tests and command isolation
+ */
 export type FoldingRangeProviderExecutor = (uri: vscode.Uri) => Thenable<FoldingRangeProviderResult>;
 
+/**
+ * Collects, normalises, merges, and caches provider-backed regions for a document
+ */
 export async function getRegions(
 	document: vscode.TextDocument,
 	executeSymbolProvider: SymbolProviderExecutor = defaultSymbolProviderExecutor,
@@ -27,6 +40,7 @@ export async function getRegions(
 		return cached.nodes;
 	}
 
+	// Symbols and folding ranges come from separate VS Code providers
 	const [symbols, foldingRanges] = await Promise.all([
 		collectSymbols(document.uri, executeSymbolProvider),
 		collectFoldingRanges(document.uri, executeFoldingRangeProvider),
@@ -41,6 +55,9 @@ export async function getRegions(
 	return nodes;
 }
 
+/**
+ * Converts provider failures into absent symbols so folding can degrade cleanly
+ */
 async function collectSymbols(
 	uri: vscode.Uri,
 	executeSymbolProvider: SymbolProviderExecutor
@@ -52,6 +69,9 @@ async function collectSymbols(
 	}
 }
 
+/**
+ * Converts provider failures into absent folding ranges so symbols still work
+ */
 async function collectFoldingRanges(
 	uri: vscode.Uri,
 	executeFoldingRangeProvider: FoldingRangeProviderExecutor
@@ -63,6 +83,9 @@ async function collectFoldingRanges(
 	}
 }
 
+/**
+ * Production bridge to VS Code's document-symbol provider command
+ */
 function defaultSymbolProviderExecutor(uri: vscode.Uri): Thenable<SymbolProviderResult> {
 	return vscode.commands.executeCommand<SymbolProviderResult>(
 		"vscode.executeDocumentSymbolProvider",
@@ -70,6 +93,9 @@ function defaultSymbolProviderExecutor(uri: vscode.Uri): Thenable<SymbolProvider
 	);
 }
 
+/**
+ * Production bridge to VS Code's folding-range provider command
+ */
 function defaultFoldingRangeProviderExecutor(uri: vscode.Uri): Thenable<FoldingRangeProviderResult> {
 	return vscode.commands.executeCommand<FoldingRangeProviderResult>(
 		"vscode.executeFoldingRangeProvider",

--- a/src/engine/regionCollector.ts
+++ b/src/engine/regionCollector.ts
@@ -1,7 +1,8 @@
 import * as vscode from "vscode";
 import type { RegionNode } from "../model/region";
-import { normalizeSymbols } from "./symbolNormaliser";
 import { getCachedRegions, setCachedRegions } from "../util/cache";
+import { attachFoldingOnlyNodes } from "./foldingRangeRefiner";
+import { normalizeSymbols } from "./symbolNormaliser";
 
 type SymbolProviderResult =
 	| vscode.DocumentSymbol[]
@@ -9,37 +10,69 @@ type SymbolProviderResult =
 	| null
 	| undefined;
 
+type FoldingRangeProviderResult = vscode.FoldingRange[] | null | undefined;
+
 export type SymbolProviderExecutor = (uri: vscode.Uri) => Thenable<SymbolProviderResult>;
+export type FoldingRangeProviderExecutor = (uri: vscode.Uri) => Thenable<FoldingRangeProviderResult>;
 
 export async function getRegions(
 	document: vscode.TextDocument,
-	executeSymbolProvider: SymbolProviderExecutor = defaultSymbolProviderExecutor
+	executeSymbolProvider: SymbolProviderExecutor = defaultSymbolProviderExecutor,
+	executeFoldingRangeProvider: FoldingRangeProviderExecutor = defaultFoldingRangeProviderExecutor
 ): Promise<RegionNode[]> {
+	const uri = document.uri.toString();
+	const cached = getCachedRegions(uri);
+
+	if(cached && cached.documentVersion === document.version) {
+		return cached.nodes;
+	}
+
+	const [symbols, foldingRanges] = await Promise.all([
+		collectSymbols(document.uri, executeSymbolProvider),
+		collectFoldingRanges(document.uri, executeFoldingRangeProvider),
+	]);
+	const nodes = attachFoldingOnlyNodes(normalizeSymbols(symbols), foldingRanges);
+
+	setCachedRegions(uri, {
+		documentVersion: document.version,
+		nodes,
+	});
+
+	return nodes;
+}
+
+async function collectSymbols(
+	uri: vscode.Uri,
+	executeSymbolProvider: SymbolProviderExecutor
+): Promise<SymbolProviderResult> {
 	try {
-		const uri = document.uri.toString();
-		const cached = getCachedRegions(uri);
-		
-		if(cached && cached.documentVersion === document.version) {
-			return cached.nodes;
-		}
-
-		const symbols = await executeSymbolProvider(document.uri);
-		const nodes = normalizeSymbols(symbols);
-		
-		setCachedRegions(uri, {
-			documentVersion: document.version,
-			nodes
-		});
-
-		return nodes;
+		return await executeSymbolProvider(uri);
 	} catch {
-		return [];
+		return undefined;
+	}
+}
+
+async function collectFoldingRanges(
+	uri: vscode.Uri,
+	executeFoldingRangeProvider: FoldingRangeProviderExecutor
+): Promise<FoldingRangeProviderResult> {
+	try {
+		return await executeFoldingRangeProvider(uri);
+	} catch {
+		return undefined;
 	}
 }
 
 function defaultSymbolProviderExecutor(uri: vscode.Uri): Thenable<SymbolProviderResult> {
 	return vscode.commands.executeCommand<SymbolProviderResult>(
 		"vscode.executeDocumentSymbolProvider",
+		uri
+	);
+}
+
+function defaultFoldingRangeProviderExecutor(uri: vscode.Uri): Thenable<FoldingRangeProviderResult> {
+	return vscode.commands.executeCommand<FoldingRangeProviderResult>(
+		"vscode.executeFoldingRangeProvider",
 		uri
 	);
 }

--- a/src/engine/semanticRefiner.ts
+++ b/src/engine/semanticRefiner.ts
@@ -1,5 +1,11 @@
 import type { RegionNode } from "../model/region";
 
+/**
+ * Placeholder for future semantic-token enrichment
+ *
+ * The current provider-backed model already carries the categories that this
+ * phase can safely support, so the refiner intentionally returns the tree as-is
+ */
 export function refineWithSemanticTokens(rootNodes: RegionNode[]): RegionNode[] {
     return rootNodes;
 }

--- a/src/engine/symbolNormaliser.ts
+++ b/src/engine/symbolNormaliser.ts
@@ -2,6 +2,12 @@ import * as vscode from "vscode";
 import type { RegionNode } from "../model/region";
 import { mapSymbolKind } from "../util/symbolKindMap";
 
+/**
+ * Converts VS Code symbol-provider output into Semantic Fold region nodes
+ *
+ * Hierarchical DocumentSymbol results preserve parent-child relationships,
+ * while flat SymbolInformation results become top-level fallback regions
+ */
 export function normalizeSymbols(
 	symbols: vscode.DocumentSymbol[] | vscode.SymbolInformation[] | null | undefined
 ): RegionNode[] {
@@ -9,21 +15,23 @@ export function normalizeSymbols(
 		return [];
 	}
 
-	return symbols
-		.map((symbol, index) => {
-			if(isDocumentSymbol(symbol)) {
-				return symbolRegionNode(symbol, undefined, 1, `${index}`);
-			}
+	return symbols.map((symbol, index) => {
+		if(isDocumentSymbol(symbol)) {
+			return symbolRegionNode(symbol, undefined, 1, `${index}`);
+		}
 
-			if(isSymbolInformation(symbol)) {
-				return symbolInformationRegionNode(symbol, index);
-			}
+		if(isSymbolInformation(symbol)) {
+			return symbolInformationRegionNode(symbol, index);
+		}
 
-			return undefined;
-		})
-		.filter((region): region is RegionNode => region !== undefined);
+		return undefined;
+	})
+	.filter((region): region is RegionNode => region !== undefined);
 }
 
+/**
+ * Recursively converts a hierarchical DocumentSymbol into a RegionNode tree
+ */
 function symbolRegionNode(
 	symbol: vscode.DocumentSymbol,
 	parent: RegionNode | undefined,
@@ -51,6 +59,9 @@ function symbolRegionNode(
 	return node;
 }
 
+/**
+ * Converts a flat SymbolInformation item into a top-level fallback region
+ */
 function symbolInformationRegionNode(
 	symbol: vscode.SymbolInformation,
 	index: number
@@ -69,6 +80,9 @@ function symbolInformationRegionNode(
 	};
 }
 
+/**
+ * Builds deterministic ids for hierarchical symbols using their path and range
+ */
 function createNodeId(symbol: vscode.DocumentSymbol, path: string): string {
 	return [
 		"documentSymbol",
@@ -81,6 +95,9 @@ function createNodeId(symbol: vscode.DocumentSymbol, path: string): string {
 	].join(":");
 }
 
+/**
+ * Builds deterministic ids for flat symbols using URI, path, and range
+ */
 function symbolInformationNodeId(symbol: vscode.SymbolInformation, path: string): string {
 	return [
 		"symbolInformation",
@@ -93,6 +110,9 @@ function symbolInformationNodeId(symbol: vscode.SymbolInformation, path: string)
 	].join(":");
 }
 
+/**
+ * Validates a provider value before treating it as a DocumentSymbol
+ */
 function isDocumentSymbol(value: unknown): value is vscode.DocumentSymbol {
 	const symbol = value as Partial<vscode.DocumentSymbol>;
 
@@ -104,6 +124,9 @@ function isDocumentSymbol(value: unknown): value is vscode.DocumentSymbol {
 		&& symbol.range.end.line >= symbol.range.start.line;
 }
 
+/**
+ * Validates a provider value before treating it as SymbolInformation
+ */
 function isSymbolInformation(value: unknown): value is vscode.SymbolInformation {
 	const symbol = value as Partial<vscode.SymbolInformation>;
 	const location = symbol.location as Partial<vscode.Location> | undefined;
@@ -116,12 +139,18 @@ function isSymbolInformation(value: unknown): value is vscode.SymbolInformation 
 		&& location.range.end.line >= location.range.start.line;
 }
 
+/**
+ * Validates that a value has VS Code range-like positions
+ */
 function isRange(value: unknown): value is vscode.Range {
 	const range = value as Partial<vscode.Range>;
 
 	return range !== undefined && isPosition(range.start) && isPosition(range.end);
 }
 
+/**
+ * Validates zero-based non-negative editor positions
+ */
 function isPosition(value: unknown): value is vscode.Position {
 	const position = value as Partial<vscode.Position>;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import {
 	collapseCommand,
 	toggleClassMembersCommand,
 	toggleFunctionsInVariablesCommand,
+	toggleImportsCommand,
 	toggleMethodsInClassesCommand,
 	toggleTypesCommand,
 	toggleVariablesCommand,
@@ -37,6 +38,10 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand(
 			"semanticFold.toggleFunctionsInVariables",
 			toggleFunctionsInVariablesCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleImports",
+			toggleImportsCommand
 		),
 		// Register cache invalidation listeners
 		vscode.workspace.onDidChangeTextDocument((event) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,6 +12,9 @@ import { expandCommand } from "./commands/expand";
 import { toggleCommand } from "./commands/toggle";
 import { invalidateRegionCache, invalidateRegionCacheDebounced } from "./util/cache";
 
+/**
+ * Delay used to avoid rebuilding regions for every keystroke
+ */
 const DEBOUNCE_DELAY_MS = 500;
 
 export function activate(context: vscode.ExtensionContext): void {
@@ -43,7 +46,7 @@ export function activate(context: vscode.ExtensionContext): void {
 			"semanticFold.toggleImports",
 			toggleImportsCommand
 		),
-		// Register cache invalidation listeners
+		// Text changes use debounce because providers can be expensive
 		vscode.workspace.onDidChangeTextDocument((event) => {
 			const documentUri = event.document.uri.toString();
 			invalidateRegionCacheDebounced(documentUri, DEBOUNCE_DELAY_MS);
@@ -55,4 +58,7 @@ export function activate(context: vscode.ExtensionContext): void {
 	);
 }
 
+/**
+ * No explicit shutdown work is required because disposables live in context
+ */
 export function deactivate(): void {}

--- a/src/model/filters.ts
+++ b/src/model/filters.ts
@@ -1,26 +1,82 @@
 import { REGION_KINDS, type RegionKind } from "./region";
 
+/**
+ * User-facing filter contract accepted by command arguments and convenience commands
+ */
 export interface CollapseFilter {
+	/**
+	 * Region kinds to include before exclusions are applied
+	 */
 	kinds?: RegionKind[];
+
+	/**
+	 * Region kinds to remove after inclusion matching
+	 */
 	excludeKinds?: RegionKind[];
 
+	/**
+	 * Exact normalised symbol hierarchy depth
+	 */
 	exactSymbolDepth?: number;
+
+	/**
+	 * Minimum normalised symbol hierarchy depth
+	 */
 	minSymbolDepth?: number;
+
+	/**
+	 * Maximum normalised symbol hierarchy depth
+	 */
 	maxSymbolDepth?: number;
 
+	/**
+	 * Exact folding-range hierarchy depth
+	 */
 	exactFoldDepth?: number;
+
+	/**
+	 * Minimum minimum folding-range hierarchy depth
+	 */
 	minFoldDepth?: number;
+
+	/**
+	 * Maximum maximum folding-range hierarchy depth
+	 */
 	maxFoldDepth?: number;
 
+	/**
+	 * Immediate parent kinds required for a match
+	 */
 	parentKinds?: RegionKind[];
+
+	/**
+	 * Any ancestor kinds required for a match
+	 */
 	ancestorKinds?: RegionKind[];
 
+	/**
+	 * Reserved name filter accepted only when the regex is valid
+	 */
 	nameRegex?: string;
 }
 
+/**
+ * Normalised command arguments consumed by fold execution
+ */
 export interface CollapseArgs {
+	/**
+	 * Optional structural filter for narrowing fold targets
+	 */
 	filter?: CollapseFilter;
+
+	/**
+	 * Requested fold behaviour
+	 */
 	mode?: "collapse" | "expand" | "toggle";
+
+	/**
+	 * Option for future cursor-aware command behaviour
+	 */
 	preserveCursorContext?: boolean;
 }
 
@@ -53,6 +109,9 @@ const kindFilterKeys: KindFilterKey[] = [
 
 const regionKinds = new Set<string>(REGION_KINDS);
 
+/**
+ * Converts arbitrary command payloads into the safe internal command shape
+ */
 export function normaliseArgs(args: unknown, mode: CollapseArgs["mode"] = "collapse"): CollapseArgs {
 	const payload = isRecord(args) ? args : {};
 	const normalisedArgs: CollapseArgs = { mode: normaliseMode(payload.mode) ?? mode };
@@ -69,6 +128,9 @@ export function normaliseArgs(args: unknown, mode: CollapseArgs["mode"] = "colla
 	return normalisedArgs;
 }
 
+/**
+ * Accepts only known command modes
+ */
 function normaliseMode(value: unknown): CommandMode | undefined {
 	if(value === "collapse" || value === "expand" || value === "toggle") {
 		return value;
@@ -77,6 +139,9 @@ function normaliseMode(value: unknown): CommandMode | undefined {
 	return undefined;
 }
 
+/**
+ * Sanitises the optional filter object while dropping unsupported fields
+ */
 export function normaliseCollapseFilter(filter: unknown): CollapseFilter | undefined {
 	if(!isRecord(filter)) {
 		return undefined;
@@ -111,6 +176,9 @@ export function normaliseCollapseFilter(filter: unknown): CollapseFilter | undef
 	return normalisedFilter;
 }
 
+/**
+ * Deduplicates region-kind arrays and removes unknown values
+ */
 function normaliseRegionKinds(value: unknown): RegionKind[] {
 	if(!Array.isArray(value)) {
 		return [];
@@ -119,6 +187,9 @@ function normaliseRegionKinds(value: unknown): RegionKind[] {
 	return [...new Set(value)].filter(isRegionKind);
 }
 
+/**
+ * Accepts one-based positive integer depths only
+ */
 function normaliseDepth(value: unknown): number | undefined {
 	if(typeof value !== "number" || !Number.isInteger(value) || value < 1) {
 		return undefined;
@@ -127,10 +198,16 @@ function normaliseDepth(value: unknown): number | undefined {
 	return value;
 }
 
+/**
+ * Narrows arbitrary values to the normalised region-kind union
+ */
 function isRegionKind(value: unknown): value is RegionKind {
 	return typeof value === "string" && regionKinds.has(value);
 }
 
+/**
+ * Validates regex strings without applying them yet
+ */
 function isValidRegex(value: string): boolean {
 	try {
 		new RegExp(value);
@@ -141,6 +218,9 @@ function isValidRegex(value: string): boolean {
 	}
 }
 
+/**
+ * Narrows arbitrary command payloads to object-like values
+ */
 function isRecord(value: unknown): value is Record<string, unknown> {
 	return typeof value === "object" && value !== null;
 }

--- a/src/model/region.ts
+++ b/src/model/region.ts
@@ -1,3 +1,9 @@
+/**
+ * Normalised categories used by Semantic Fold filters
+ *
+ * These are intentionally smaller than VS Code's full symbol-kind enum so
+ * command payloads stay stable across symbol and folding-range providers
+ */
 export const REGION_KINDS = [
 	"class",
 	"struct",
@@ -17,23 +23,72 @@ export const REGION_KINDS = [
 	"unknown",
 ] as const;
 
+/**
+ * Union type for every supported normalised region category
+ */
 export type RegionKind = typeof REGION_KINDS[number];
 
+/**
+ * Provider-neutral region shape consumed by filtering and fold execution
+ */
 export interface RegionNode {
+	/**
+	 * Stable identifier built from provider source, path, range, and name data
+	 */
 	id: string;
+
+	/**
+	 * Display or symbol name when the provider supplies one
+	 */
 	name?: string;
+
+	/**
+	 * Normalised region category used by command filters
+	 */
 	kind: RegionKind;
 
+	/**
+	 * Inclusive zero-based start line for the full provider range
+	 */
 	rangeStartLine: number;
+
+	/**
+	 * Inclusive zero-based end line for the full provider range
+	 */
 	rangeEndLine: number;
+
+	/**
+	 * Zero-based line passed to VS Code when executing fold commands
+	 */
 	selectionLine: number;
 
+	/**
+	 * Nesting depth from document-symbol hierarchy or fallback top-level placement
+	 */
 	symbolDepth: number;
+
+	/**
+	 * Nesting depth for folding-range-only nodes once merged into the tree
+	 */
 	foldDepth?: number;
 
+	/**
+	 * Parent node when the provider or folding-range merge can establish hierarchy
+	 */
 	parent?: RegionNode;
+
+	/**
+	 * Child regions in document order
+	 */
 	children: RegionNode[];
 
+	/**
+	 * Provider path that produced the node
+	 */
 	source: "documentSymbol" | "symbolInformation" | "foldingRange";
+
+	/**
+	 * Original VS Code symbol kind for symbol-backed nodes
+	 */
 	symbolKind?: number;
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -586,6 +586,29 @@ suite("Folding Range Refinement", () => {
 		);
 	});
 
+	test("nests folding-only nodes inside symbol parents with separate symbol and fold depths", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 30);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 4, 25);
+		classSymbol.children.push(methodSymbol);
+
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(8, 12, vscode.FoldingRangeKind.Comment),
+			new vscode.FoldingRange(6, 20, vscode.FoldingRangeKind.Region),
+		]);
+
+		assert.deepStrictEqual(
+			flattenRegions(regions).map((region) => {
+				return `${region.name}:${region.kind}:${region.symbolDepth}:${region.foldDepth ?? "none"}`;
+			}),
+			[
+				"Example:class:1:none",
+				"run:method:2:none",
+				"region:region:3:1",
+				"comment:comment:4:2",
+			]
+		);
+	});
+
 	test("supports filtering folding-only nodes after they are attached to symbol parents", () => {
 		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 20);
 		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 5, 15);
@@ -1243,6 +1266,31 @@ suite("Region Filtering", () => {
 				exactSymbolDepth: 3,
 			}).map((region) => region.name),
 			["formatPayload"]
+		);
+	});
+
+	test("combines symbol depth, parent, and ancestor filters across nested folding ranges", () => {
+		const regions = createMixedSymbolAndFoldingFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["comment"],
+				parentKinds: ["region"],
+				ancestorKinds: ["method"],
+				exactSymbolDepth: 4,
+			}).map((region) => `${region.kind}:${region.selectionLine}`),
+			["comment:22"]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["comment"],
+					parentKinds: ["region"],
+					ancestorKinds: ["method"],
+					exactSymbolDepth: 4,
+				},
+			}, regions)),
+			[22]
 		);
 	});
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -2,6 +2,7 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDefaultCollapseMode } from "../commands/collapse";
 import { filterRegions, flattenRegions, getAncestors, hasHierarchy } from "../engine/filterEngine";
+import { attachFoldingOnlyNodes, normaliseFoldingRanges } from "../engine/foldingRangeRefiner";
 import {
 	collectFoldableRegions,
 	collectSelectionLines,
@@ -12,7 +13,7 @@ import {
 import { getRegions } from "../engine/regionCollector";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
 import { type CollapseFilter, normaliseArgs, normaliseCollapseFilter } from "../model/filters";
-import { mapSymbolKind } from "../util/symbolKindMap";
+import { mapFoldingRangeKind, mapSymbolKind } from "../util/symbolKindMap";
 
 suite("Semantic Fold Foundation", () => {
 	test("registers collapse, expand, and toggle commands", async () => {
@@ -28,27 +29,39 @@ suite("Semantic Fold Foundation", () => {
 		assert.ok(commands.includes("semanticFold.toggleTypes"));
 		assert.ok(commands.includes("semanticFold.toggleVariables"));
 		assert.ok(commands.includes("semanticFold.toggleFunctionsInVariables"));
+		assert.ok(commands.includes("semanticFold.toggleImports"));
 	});
 });
 
-suite("Document Symbol Collection", () => {
-	test("requests document symbols for the supplied document uri", async () => {
+suite("Document Region Collection", () => {
+	test("requests document symbols and folding ranges for the supplied document uri", async () => {
 		const document = await vscode.workspace.openTextDocument({
-			content: "class Example {\n\tmethod() {}\n}\n",
+			content: "import value from \"module\";\nimport other from \"other\";\n\nclass Example {\n\tmethod() {}\n}\n",
 			language: "typescript",
 		});
-		const expectedSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 2);
-		let requestedUri: vscode.Uri | undefined;
+		const expectedSymbol = createSymbol("Example", vscode.SymbolKind.Class, 3, 5);
+		let requestedSymbolUri: vscode.Uri | undefined;
+		let requestedFoldingRangeUri: vscode.Uri | undefined;
 
 		const regions = await getRegions(document, async (uri) => {
-			requestedUri = uri;
+			requestedSymbolUri = uri;
 
 			return [expectedSymbol];
+		}, async (uri) => {
+			requestedFoldingRangeUri = uri;
+
+			return [new vscode.FoldingRange(0, 1, vscode.FoldingRangeKind.Imports)];
 		});
 
-		assert.strictEqual(requestedUri?.toString(), document.uri.toString());
-		assert.strictEqual(regions.length, 1);
-		assert.strictEqual(regions[0].name, "Example");
+		assert.strictEqual(requestedSymbolUri?.toString(), document.uri.toString());
+		assert.strictEqual(requestedFoldingRangeUri?.toString(), document.uri.toString());
+		assert.deepStrictEqual(
+			regions.map((region) => `${region.kind}:${region.source}:${region.selectionLine}`),
+			[
+				"import:foldingRange:0",
+				"class:documentSymbol:3",
+			]
+		);
 	});
 
 	test("returns an empty region tree when the provider fails", async () => {
@@ -59,9 +72,29 @@ suite("Document Symbol Collection", () => {
 
 		const regions = await getRegions(document, async () => {
 			throw new Error("provider failed");
+		}, async () => {
+			throw new Error("provider failed");
 		});
 
 		assert.deepStrictEqual(regions, []);
+	});
+
+	test("keeps symbol regions when folding ranges are unavailable", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "class Example {\n\tmethod() {}\n}\n",
+			language: "typescript",
+		});
+		const expectedSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 2);
+
+		const regions = await getRegions(document, async () => {
+			return [expectedSymbol];
+		}, async () => {
+			throw new Error("provider failed");
+		});
+
+		assert.strictEqual(regions.length, 1);
+		assert.strictEqual(regions[0].name, "Example");
+		assert.strictEqual(regions[0].source, "documentSymbol");
 	});
 
 	test("accepts flat symbol information provider results", async () => {
@@ -79,6 +112,8 @@ suite("Document Symbol Collection", () => {
 
 		const regions = await getRegions(document, async () => {
 			return [helperSymbol];
+		}, async () => {
+			return [];
 		});
 
 		assert.strictEqual(regions.length, 1);
@@ -239,6 +274,76 @@ suite("Symbol Kind Mapping", () => {
 
 	test("falls back safely for unmapped symbol kinds", () => {
 		assert.strictEqual(mapSymbolKind(999 as vscode.SymbolKind), "unknown");
+	});
+
+	test("maps folding range kinds to normalised categories", () => {
+		assert.strictEqual(mapFoldingRangeKind(vscode.FoldingRangeKind.Imports), "import");
+		assert.strictEqual(mapFoldingRangeKind(vscode.FoldingRangeKind.Comment), "comment");
+		assert.strictEqual(mapFoldingRangeKind(vscode.FoldingRangeKind.Region), "region");
+		assert.strictEqual(mapFoldingRangeKind(undefined), "unknown");
+	});
+});
+
+suite("Folding Range Refinement", () => {
+	test("maps import folding ranges into folding-only regions", () => {
+		const regions = normaliseFoldingRanges([
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+		]);
+
+		assert.strictEqual(regions.length, 1);
+		assert.strictEqual(regions[0].kind, "import");
+		assert.strictEqual(regions[0].source, "foldingRange");
+		assert.strictEqual(regions[0].rangeStartLine, 0);
+		assert.strictEqual(regions[0].rangeEndLine, 2);
+		assert.strictEqual(regions[0].selectionLine, 0);
+		assert.strictEqual(regions[0].symbolDepth, 1);
+		assert.strictEqual(regions[0].foldDepth, 1);
+	});
+
+	test("ignores unsupported and malformed folding ranges", () => {
+		assert.deepStrictEqual(
+			normaliseFoldingRanges([
+				new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Comment),
+				new vscode.FoldingRange(4, 6),
+				new vscode.FoldingRange(7.5, 9, vscode.FoldingRangeKind.Imports),
+				{ start: 10, end: 8, kind: vscode.FoldingRangeKind.Imports } as vscode.FoldingRange,
+			]),
+			[]
+		);
+	});
+
+	test("adds import nodes in document order with symbol nodes", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 10);
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+		]);
+
+		assert.deepStrictEqual(
+			regions.map((region) => `${region.kind}:${region.selectionLine}`),
+			[
+				"import:0",
+				"class:4",
+			]
+		);
+	});
+
+	test("selects foldable import ranges through the generic command filter", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 10);
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+		]);
+
+		const foldableRegions = selectFoldableRegions({
+			filter: {
+				kinds: ["import"],
+			},
+		}, regions);
+
+		assert.deepStrictEqual(
+			foldableRegions.map((region) => `${region.kind}:${region.selectionLine}`),
+			["import:0"]
+		);
+		assert.deepStrictEqual(collectSelectionLines(foldableRegions), [0]);
 	});
 });
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -11,8 +11,16 @@ import {
 	TrackedFoldState,
 } from "../engine/foldExecutor";
 import { getRegions } from "../engine/regionCollector";
+import { refineWithSemanticTokens } from "../engine/semanticRefiner";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
 import { type CollapseFilter, normaliseArgs, normaliseCollapseFilter } from "../model/filters";
+import {
+	clearRegionCache,
+	getCachedRegions,
+	invalidateRegionCache,
+	invalidateRegionCacheDebounced,
+	setCachedRegions,
+} from "../util/cache";
 import { mapFoldingRangeKind, mapSymbolKind } from "../util/symbolKindMap";
 
 suite("Semantic Fold Foundation", () => {
@@ -97,6 +105,30 @@ suite("Document Region Collection", () => {
 		assert.strictEqual(regions[0].source, "documentSymbol");
 	});
 
+	test("keeps folding ranges when symbols are unavailable", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "import value from \"module\";\nimport other from \"other\";\n\n// first\n// second\n",
+			language: "typescript",
+		});
+
+		const regions = await getRegions(document, async () => {
+			throw new Error("provider failed");
+		}, async () => {
+			return [
+				new vscode.FoldingRange(0, 1, vscode.FoldingRangeKind.Imports),
+				new vscode.FoldingRange(3, 4, vscode.FoldingRangeKind.Comment),
+			];
+		});
+
+		assert.deepStrictEqual(
+			regions.map((region) => `${region.kind}:${region.source}:${region.selectionLine}`),
+			[
+				"import:foldingRange:0",
+				"comment:foldingRange:3",
+			]
+		);
+	});
+
 	test("accepts flat symbol information provider results", async () => {
 		const document = await vscode.workspace.openTextDocument({
 			content: "function helper() {\n\treturn true;\n}\n",
@@ -175,6 +207,43 @@ suite("Document Region Collection", () => {
 		assert.strictEqual(regions1.length, 1);
 		assert.strictEqual(regions2.length, 1);
 	});
+
+	test("caches merged symbol and folding-range results for the same document version", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "import value from \"module\";\nimport other from \"other\";\n\nclass Example {}\n",
+			language: "typescript",
+		});
+		const expectedSymbol = createSymbol("Example", vscode.SymbolKind.Class, 3, 3);
+		let symbolProviderCallCount = 0;
+		let foldingProviderCallCount = 0;
+
+		const regions1 = await getRegions(document, async () => {
+			symbolProviderCallCount++;
+
+			return [expectedSymbol];
+		}, async () => {
+			foldingProviderCallCount++;
+
+			return [new vscode.FoldingRange(0, 1, vscode.FoldingRangeKind.Imports)];
+		});
+
+		const regions2 = await getRegions(document, async () => {
+			symbolProviderCallCount++;
+
+			return [expectedSymbol];
+		}, async () => {
+			foldingProviderCallCount++;
+
+			return [new vscode.FoldingRange(0, 1, vscode.FoldingRangeKind.Imports)];
+		});
+
+		assert.strictEqual(symbolProviderCallCount, 1);
+		assert.strictEqual(foldingProviderCallCount, 1);
+		assert.deepStrictEqual(
+			regions2.map((region) => `${region.kind}:${region.selectionLine}`),
+			regions1.map((region) => `${region.kind}:${region.selectionLine}`)
+		);
+	});
 });
 
 suite("Document Symbol Normalisation", () => {
@@ -213,6 +282,30 @@ suite("Document Symbol Normalisation", () => {
 		);
 	});
 
+	test("ignores malformed nested document symbols while preserving valid siblings", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 12);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 2, 6);
+		const propertySymbol = createSymbol("name", vscode.SymbolKind.Property, 8, 10);
+
+		classSymbol.children.push(
+			methodSymbol,
+			{ name: "broken" } as unknown as vscode.DocumentSymbol,
+			propertySymbol
+		);
+
+		const regions = normalizeSymbols([classSymbol]);
+		const classRegion = regions[0];
+
+		assert.deepStrictEqual(
+			classRegion.children.map((region) => `${region.name}:${region.kind}:${region.symbolDepth}`),
+			[
+				"run:method:2",
+				"name:property:2",
+			]
+		);
+		assert.ok(classRegion.children.every((region) => region.parent === classRegion));
+	});
+
 	test("normalises flat symbol information into top-level fallback nodes", () => {
 		const uri = vscode.Uri.parse("file:///workspace/example.ts");
 		const symbols = [
@@ -244,11 +337,15 @@ suite("Document Symbol Normalisation", () => {
 suite("Symbol Kind Mapping", () => {
 	test("keeps callable and member symbol kinds distinct", () => {
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Struct), "struct");
+		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Module), "namespace");
+		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Namespace), "namespace");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Function), "function");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Method), "method");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Constructor), "constructor");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Field), "field");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Property), "property");
+		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Variable), "variable");
+		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Constant), "variable");
 		assert.strictEqual(mapSymbolKind(vscode.SymbolKind.Object), "object");
 	});
 
@@ -281,6 +378,51 @@ suite("Symbol Kind Mapping", () => {
 		assert.strictEqual(mapFoldingRangeKind(vscode.FoldingRangeKind.Comment), "comment");
 		assert.strictEqual(mapFoldingRangeKind(vscode.FoldingRangeKind.Region), "region");
 		assert.strictEqual(mapFoldingRangeKind(undefined), "unknown");
+	});
+});
+
+suite("Region Cache", () => {
+	test("stores, reads, invalidates, and clears cached region entries", () => {
+		const documentUri = "test://cache/direct";
+		const nodes = createFilterFixture();
+
+		clearRegionCache();
+		setCachedRegions(documentUri, {
+			documentVersion: 3,
+			nodes,
+		});
+
+		assert.strictEqual(getCachedRegions(documentUri)?.documentVersion, 3);
+		assert.strictEqual(getCachedRegions(documentUri)?.nodes, nodes);
+
+		invalidateRegionCache(documentUri);
+		assert.strictEqual(getCachedRegions(documentUri), undefined);
+
+		setCachedRegions(documentUri, {
+			documentVersion: 4,
+			nodes,
+		});
+		clearRegionCache();
+		assert.strictEqual(getCachedRegions(documentUri), undefined);
+	});
+
+	test("debounces cache invalidation until the requested delay elapses", async () => {
+		const documentUri = "test://cache/debounce";
+		const nodes = createFilterFixture();
+
+		clearRegionCache();
+		setCachedRegions(documentUri, {
+			documentVersion: 1,
+			nodes,
+		});
+		invalidateRegionCacheDebounced(documentUri, 20);
+
+		assert.strictEqual(getCachedRegions(documentUri)?.nodes, nodes);
+
+		await delay(50);
+
+		assert.strictEqual(getCachedRegions(documentUri), undefined);
+		clearRegionCache();
 	});
 });
 
@@ -406,6 +548,22 @@ suite("Folding Range Refinement", () => {
 		assert.deepStrictEqual(
 			collectSelectionLines(selectFoldableRegions({}, regions)),
 			[0]
+		);
+	});
+
+	test("does not duplicate folding ranges that share a symbol selection line", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 12);
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(4, 14, vscode.FoldingRangeKind.Region),
+		]);
+
+		assert.deepStrictEqual(
+			flattenRegions(regions).map((region) => `${region.kind}:${region.selectionLine}:${region.rangeEndLine}`),
+			["class:4:12"]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({}, regions)),
+			[4]
 		);
 	});
 
@@ -652,6 +810,27 @@ suite("Command Argument Normalisation", () => {
 				},
 				mode: "collapse",
 				preserveCursorContext: true,
+			}
+		);
+	});
+
+	test("normalises every supported depth boundary from command payloads", () => {
+		assert.deepStrictEqual(
+			normaliseCollapseFilter({
+				exactSymbolDepth: 2,
+				minSymbolDepth: 1,
+				maxSymbolDepth: 4,
+				exactFoldDepth: 3,
+				minFoldDepth: 2,
+				maxFoldDepth: 5,
+			}),
+			{
+				exactSymbolDepth: 2,
+				minSymbolDepth: 1,
+				maxSymbolDepth: 4,
+				exactFoldDepth: 3,
+				minFoldDepth: 2,
+				maxFoldDepth: 5,
 			}
 		);
 	});
@@ -1067,6 +1246,23 @@ suite("Region Filtering", () => {
 		);
 	});
 
+	test("combines exclusions and depth bounds across symbol and folding-range categories", () => {
+		const regions = createMixedSymbolAndFoldingFixture();
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["import", "method", "comment"],
+				excludeKinds: ["comment"],
+				minSymbolDepth: 1,
+				maxSymbolDepth: 2,
+			}).map((region) => `${region.kind}:${region.selectionLine}`),
+			[
+				"import:0",
+				"method:10",
+			]
+		);
+	});
+
 	test("matches convenience command filters for common structural workflows", () => {
 		const regions = createConvenienceCommandFixture();
 
@@ -1168,6 +1364,14 @@ suite("Region Filtering", () => {
 			}).map((region) => region.name),
 			[]
 		);
+	});
+});
+
+suite("Semantic Token Refinement", () => {
+	test("returns the provider-backed region tree unchanged until semantic refinement is implemented", () => {
+		const regions = createMixedSymbolAndFoldingFixture();
+
+		assert.strictEqual(refineWithSemanticTokens(regions), regions);
 	});
 });
 
@@ -1284,6 +1488,32 @@ suite("Fold Execution Guards", () => {
 		}]);
 	});
 
+	test("executes multifaceted filters across symbol and folding-range targets", async () => {
+		const regions = createMixedSymbolAndFoldingFixture();
+		const executedCommands: ExecutedCommand[] = [];
+
+		await execFoldCommand({
+			filter: {
+				kinds: ["import", "method", "comment"],
+				excludeKinds: ["comment"],
+				minSymbolDepth: 1,
+				maxSymbolDepth: 2,
+			},
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, new TrackedFoldState(), "test://multifaceted");
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.fold",
+			levels: 1,
+			selectionLines: [0, 10],
+		}]);
+	});
+
 	test("collapses every toggle target when any target is expanded", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
@@ -1346,6 +1576,91 @@ suite("Fold Execution Guards", () => {
 			levels: 1,
 			selectionLines: [2, 6, 12],
 		}]);
+	});
+
+	test("updates tracked state after explicit expand so later toggles collapse again", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		await execFoldCommand({ mode: "collapse" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-after-expand");
+
+		await execFoldCommand({ mode: "expand" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-after-expand");
+
+		await execFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://toggle-after-expand");
+
+		assert.deepStrictEqual(executedCommands, [
+			{
+				command: "editor.fold",
+				levels: 1,
+				selectionLines: [2, 6, 12],
+			},
+			{
+				command: "editor.unfold",
+				levels: 1,
+				selectionLines: [2, 6, 12],
+			},
+			{
+				command: "editor.fold",
+				levels: 1,
+				selectionLines: [2, 6, 12],
+			},
+		]);
+	});
+
+	test("tracks toggle state independently per document key", async () => {
+		const regions = createDuplicateSelectionFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		foldState.markCollapsed("test://document-a", [2, 6, 12]);
+
+		await execFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://document-b");
+
+		await execFoldCommand({ mode: "toggle" }, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://document-a");
+
+		assert.deepStrictEqual(executedCommands, [
+			{
+				command: "editor.fold",
+				levels: 1,
+				selectionLines: [2, 6, 12],
+			},
+			{
+				command: "editor.unfold",
+				levels: 1,
+				selectionLines: [2, 6, 12],
+			},
+		]);
 	});
 
 	test("does not execute any command when no filtered nodes are foldable", async () => {
@@ -1603,6 +1918,25 @@ function createDepthFilterFixture(): ReturnType<typeof normalizeSymbols> {
 	return normalizeSymbols([classSymbol, functionSymbol]);
 }
 
+function createMixedSymbolAndFoldingFixture(): ReturnType<typeof attachFoldingOnlyNodes> {
+	const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 36);
+	const constructorSymbol = createSymbol("constructor", vscode.SymbolKind.Constructor, 5, 7);
+	const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 10, 28);
+	const nestedFunctionSymbol = createSymbol("inner", vscode.SymbolKind.Function, 14, 18);
+	const propertySymbol = createSymbol("name", vscode.SymbolKind.Property, 32, 32);
+	const helperSymbol = createSymbol("helper", vscode.SymbolKind.Function, 40, 44);
+
+	methodSymbol.children.push(nestedFunctionSymbol);
+	classSymbol.children.push(constructorSymbol, methodSymbol, propertySymbol);
+
+	return attachFoldingOnlyNodes(normalizeSymbols([classSymbol, helperSymbol]), [
+		new vscode.FoldingRange(0, 1, vscode.FoldingRangeKind.Imports),
+		new vscode.FoldingRange(12, 13, vscode.FoldingRangeKind.Comment),
+		new vscode.FoldingRange(22, 23, vscode.FoldingRangeKind.Comment),
+		new vscode.FoldingRange(20, 26, vscode.FoldingRangeKind.Region),
+	]);
+}
+
 function createFlatFallbackFixture(): ReturnType<typeof normalizeSymbols> {
 	const uri = vscode.Uri.parse("file:///workspace/flat.ts");
 
@@ -1644,4 +1978,10 @@ async function activateExtension(): Promise<void> {
 	assert.ok(extension);
 
 	await extension.activate();
+}
+
+async function delay(delayMs: number): Promise<void> {
+	return new Promise((resolve) => {
+		setTimeout(resolve, delayMs);
+	});
 }

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -472,6 +472,57 @@ suite("Folding Range Refinement", () => {
 		);
 		assert.deepStrictEqual(collectSelectionLines(foldableRegions), [0]);
 	});
+
+	test("treats unsupported folding-range categories as soft no-match results", async () => {
+		const regions = attachFoldingOnlyNodes([], [
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+		]);
+		const executedCommands: ExecutedCommand[] = [];
+
+		const commentRegions = selectFoldableRegions({
+			filter: {
+				kinds: ["comment"],
+			},
+		}, regions);
+
+		await execFoldCommand({
+			filter: {
+				kinds: ["comment"],
+			},
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, new TrackedFoldState(), "test://missing-comment-category");
+
+		assert.deepStrictEqual(commentRegions, []);
+		assert.deepStrictEqual(executedCommands, []);
+	});
+
+	test("keeps present folding-range categories available when another category is absent", () => {
+		const regions = attachFoldingOnlyNodes([], [
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+		]);
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["import"],
+				},
+			}, regions)),
+			[0]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["region"],
+				},
+			}, regions)),
+			[]
+		);
+	});
 });
 
 suite("Command Argument Normalisation", () => {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -355,6 +355,26 @@ suite("Folding Range Refinement", () => {
 		);
 	});
 
+	test("attaches nested folding-only nodes regardless of provider order", () => {
+		const regions = attachFoldingOnlyNodes([], [
+			new vscode.FoldingRange(4, 8, vscode.FoldingRangeKind.Comment),
+			new vscode.FoldingRange(0, 12, vscode.FoldingRangeKind.Region),
+		]);
+		const regionNode = regions[0];
+		const commentNode = regionNode.children[0];
+
+		assert.strictEqual(regionNode.kind, "region");
+		assert.strictEqual(commentNode.kind, "comment");
+		assert.strictEqual(commentNode.parent, regionNode);
+		assert.deepStrictEqual(
+			flattenRegions(regions).map((region) => `${region.kind}:${region.symbolDepth}:${region.foldDepth}`),
+			[
+				"region:1:1",
+				"comment:2:2",
+			]
+		);
+	});
+
 	test("keeps folding-only nodes at the root when no containing node exists", () => {
 		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 10);
 		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
@@ -386,6 +406,25 @@ suite("Folding Range Refinement", () => {
 		assert.deepStrictEqual(
 			collectSelectionLines(selectFoldableRegions({}, regions)),
 			[0]
+		);
+	});
+
+	test("keeps partially overlapping folding ranges that are not symbol duplicates", () => {
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 4, 12);
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([methodSymbol]), [
+			new vscode.FoldingRange(2, 6, vscode.FoldingRangeKind.Comment),
+		]);
+
+		assert.deepStrictEqual(
+			flattenRegions(regions).map((region) => `${region.kind}:${region.selectionLine}`),
+			[
+				"comment:2",
+				"method:4",
+			]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({}, regions)),
+			[2, 4]
 		);
 	});
 
@@ -521,6 +560,67 @@ suite("Folding Range Refinement", () => {
 				},
 			}, regions)),
 			[]
+		);
+	});
+
+	test("filters mixed symbol and folding-range categories together", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 12);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 6, 10);
+		classSymbol.children.push(methodSymbol);
+
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+			new vscode.FoldingRange(7, 8, vscode.FoldingRangeKind.Comment),
+		]);
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["import", "class", "comment"],
+			}).map((region) => `${region.kind}:${region.selectionLine}`),
+			[
+				"import:0",
+				"class:4",
+				"comment:7",
+			]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["import", "class", "comment"],
+				},
+			}, regions)),
+			[0, 4, 7]
+		);
+	});
+
+	test("combines mixed categories with relationship filters after merge", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 20);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 5, 15);
+		classSymbol.children.push(methodSymbol);
+
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(7, 9, vscode.FoldingRangeKind.Comment),
+			new vscode.FoldingRange(22, 24, vscode.FoldingRangeKind.Imports),
+		]);
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["comment", "method"],
+				ancestorKinds: ["class"],
+			}).map((region) => `${region.kind}:${region.selectionLine}`),
+			[
+				"method:5",
+				"comment:7",
+			]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["comment", "method"],
+					ancestorKinds: ["class"],
+				},
+			}, regions)),
+			[5, 7]
 		);
 	});
 });
@@ -1112,6 +1212,27 @@ suite("Fold Execution Guards", () => {
 		);
 	});
 
+	test("collects deduplicated sorted selection lines from mixed symbol and folding-range nodes", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 12);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 6, 10);
+		classSymbol.children.push(methodSymbol);
+
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+			new vscode.FoldingRange(7, 8, vscode.FoldingRangeKind.Comment),
+			new vscode.FoldingRange(4, 12, vscode.FoldingRangeKind.Region),
+		]);
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["import", "class", "comment", "region"],
+				},
+			}, regions)),
+			[0, 4, 7]
+		);
+	});
+
 	test("executes exact non-recursive fold selection lines", async () => {
 		const regions = createDuplicateSelectionFixture();
 		const executedCommands: ExecutedCommand[] = [];
@@ -1129,6 +1250,37 @@ suite("Fold Execution Guards", () => {
 			command: "editor.fold",
 			levels: 1,
 			selectionLines: [2, 6, 12],
+		}]);
+	});
+
+	test("executes mixed symbol and folding-range targets non-recursively", async () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 12);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 6, 10);
+		classSymbol.children.push(methodSymbol);
+
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+			new vscode.FoldingRange(7, 8, vscode.FoldingRangeKind.Comment),
+			new vscode.FoldingRange(4, 12, vscode.FoldingRangeKind.Region),
+		]);
+		const executedCommands: ExecutedCommand[] = [];
+
+		await execFoldCommand({
+			filter: {
+				kinds: ["import", "class", "comment", "region"],
+			},
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, new TrackedFoldState(), "test://mixed-sources");
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.fold",
+			levels: 1,
+			selectionLines: [0, 4, 7],
 		}]);
 	});
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -285,25 +285,29 @@ suite("Symbol Kind Mapping", () => {
 });
 
 suite("Folding Range Refinement", () => {
-	test("maps import folding ranges into folding-only regions", () => {
+	test("maps supported folding ranges into folding-only regions", () => {
 		const regions = normaliseFoldingRanges([
 			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+			new vscode.FoldingRange(4, 8, vscode.FoldingRangeKind.Comment),
+			new vscode.FoldingRange(10, 20, vscode.FoldingRangeKind.Region),
 		]);
 
-		assert.strictEqual(regions.length, 1);
-		assert.strictEqual(regions[0].kind, "import");
-		assert.strictEqual(regions[0].source, "foldingRange");
-		assert.strictEqual(regions[0].rangeStartLine, 0);
-		assert.strictEqual(regions[0].rangeEndLine, 2);
-		assert.strictEqual(regions[0].selectionLine, 0);
-		assert.strictEqual(regions[0].symbolDepth, 1);
-		assert.strictEqual(regions[0].foldDepth, 1);
+		assert.deepStrictEqual(
+			regions.map((region) => `${region.kind}:${region.selectionLine}:${region.rangeEndLine}`),
+			[
+				"import:0:2",
+				"comment:4:8",
+				"region:10:20",
+			]
+		);
+		assert.ok(regions.every((region) => region.source === "foldingRange"));
+		assert.ok(regions.every((region) => region.symbolDepth === 1));
+		assert.ok(regions.every((region) => region.foldDepth === 1));
 	});
 
-	test("ignores unsupported and malformed folding ranges", () => {
+	test("ignores uncategorised and malformed folding ranges", () => {
 		assert.deepStrictEqual(
 			normaliseFoldingRanges([
-				new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Comment),
 				new vscode.FoldingRange(4, 6),
 				new vscode.FoldingRange(7.5, 9, vscode.FoldingRangeKind.Imports),
 				{ start: 10, end: 8, kind: vscode.FoldingRangeKind.Imports } as vscode.FoldingRange,
@@ -342,6 +346,44 @@ suite("Folding Range Refinement", () => {
 		assert.deepStrictEqual(
 			foldableRegions.map((region) => `${region.kind}:${region.selectionLine}`),
 			["import:0"]
+		);
+		assert.deepStrictEqual(collectSelectionLines(foldableRegions), [0]);
+	});
+
+	test("selects foldable comment ranges through the generic command filter", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 8, 14);
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 5, vscode.FoldingRangeKind.Comment),
+		]);
+
+		const foldableRegions = selectFoldableRegions({
+			filter: {
+				kinds: ["comment"],
+			},
+		}, regions);
+
+		assert.deepStrictEqual(
+			foldableRegions.map((region) => `${region.kind}:${region.selectionLine}`),
+			["comment:0"]
+		);
+		assert.deepStrictEqual(collectSelectionLines(foldableRegions), [0]);
+	});
+
+	test("selects foldable region marker ranges through the generic command filter", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 8, 14);
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 5, vscode.FoldingRangeKind.Region),
+		]);
+
+		const foldableRegions = selectFoldableRegions({
+			filter: {
+				kinds: ["region"],
+			},
+		}, regions);
+
+		assert.deepStrictEqual(
+			foldableRegions.map((region) => `${region.kind}:${region.selectionLine}`),
+			["region:0"]
 		);
 		assert.deepStrictEqual(collectSelectionLines(foldableRegions), [0]);
 	});

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -331,6 +331,91 @@ suite("Folding Range Refinement", () => {
 		);
 	});
 
+	test("attaches folding-only nodes to the smallest containing symbol node", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 20);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 5, 15);
+		classSymbol.children.push(methodSymbol);
+
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(7, 9, vscode.FoldingRangeKind.Comment),
+		]);
+		const methodRegion = regions[0].children[0];
+		const commentRegion = methodRegion.children[0];
+
+		assert.strictEqual(commentRegion.kind, "comment");
+		assert.strictEqual(commentRegion.parent, methodRegion);
+		assert.strictEqual(commentRegion.symbolDepth, 3);
+		assert.deepStrictEqual(
+			flattenRegions(regions).map((region) => `${region.name}:${region.kind}`),
+			[
+				"Example:class",
+				"run:method",
+				"comment:comment",
+			]
+		);
+	});
+
+	test("keeps folding-only nodes at the root when no containing node exists", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 10);
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 2, vscode.FoldingRangeKind.Imports),
+			new vscode.FoldingRange(12, 16, vscode.FoldingRangeKind.Region),
+		]);
+
+		assert.deepStrictEqual(
+			regions.map((region) => `${region.kind}:${region.selectionLine}`),
+			[
+				"import:0",
+				"class:4",
+				"region:12",
+			]
+		);
+		assert.ok(regions.every((region) => region.parent === undefined));
+	});
+
+	test("does not duplicate folding ranges already covered by symbol-backed regions", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 10);
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(0, 10, vscode.FoldingRangeKind.Region),
+		]);
+
+		assert.deepStrictEqual(
+			flattenRegions(regions).map((region) => `${region.kind}:${region.selectionLine}`),
+			["class:0"]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({}, regions)),
+			[0]
+		);
+	});
+
+	test("supports filtering folding-only nodes after they are attached to symbol parents", () => {
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 20);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 5, 15);
+		classSymbol.children.push(methodSymbol);
+
+		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [
+			new vscode.FoldingRange(7, 9, vscode.FoldingRangeKind.Comment),
+		]);
+
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["comment"],
+				ancestorKinds: ["class"],
+			}).map((region) => `${region.kind}:${region.selectionLine}`),
+			["comment:7"]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["comment"],
+					parentKinds: ["method"],
+				},
+			}, regions)),
+			[7]
+		);
+	});
+
 	test("selects foldable import ranges through the generic command filter", () => {
 		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 4, 10);
 		const regions = attachFoldingOnlyNodes(normalizeSymbols([classSymbol]), [

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -1,5 +1,8 @@
 import type { RegionNode } from "../model/region";
 
+/**
+ * Cached region tree for a specific document version
+ */
 export interface CachedRegions {
 	documentVersion: number;
 	nodes: RegionNode[];
@@ -8,6 +11,9 @@ export interface CachedRegions {
 const regionCache = new Map<string, CachedRegions>();
 const debounceTimers = new Map<string, NodeJS.Timeout>();
 
+/**
+ * Reads the cached region tree for a document URI when present
+ */
 export function getCachedRegions(documentUri: string): CachedRegions | undefined {
 	const cached = regionCache.get(documentUri);
 	if(cached) {
@@ -18,16 +24,25 @@ export function getCachedRegions(documentUri: string): CachedRegions | undefined
 	return cached;
 }
 
+/**
+ * Stores a region tree for the exact document version that produced it
+ */
 export function setCachedRegions(documentUri: string, value: CachedRegions): void {
 	console.debug(`[semanticFold] Setting cache for ${documentUri} at version ${value.documentVersion}`);
 	regionCache.set(documentUri, value);
 }
 
+/**
+ * Removes cached region data for one document URI
+ */
 export function invalidateRegionCache(documentUri: string): void {
 	console.debug(`[semanticFold] Invalidating cache for ${documentUri}`);
 	regionCache.delete(documentUri);
 }
 
+/**
+ * Schedules cache invalidation after edits settle
+ */
 export function invalidateRegionCacheDebounced(documentUri: string, delayMs: number): void {
 	const existingTimer = debounceTimers.get(documentUri);
 	if(existingTimer) {
@@ -46,6 +61,9 @@ export function invalidateRegionCacheDebounced(documentUri: string, delayMs: num
 	debounceTimers.set(documentUri, timer);
 }
 
+/**
+ * Clears cached data and pending timers, primarily for extension shutdown or tests
+ */
 export function clearRegionCache(): void {
 	console.debug(`[semanticFold] Clearing entire region cache`);
 	regionCache.clear();

--- a/src/util/symbolKindMap.ts
+++ b/src/util/symbolKindMap.ts
@@ -1,6 +1,9 @@
 import * as vscode from "vscode";
 import type { RegionKind } from "../model/region";
 
+/**
+ * Maps VS Code document-symbol kinds into Semantic Fold's smaller kind set
+ */
 export function mapSymbolKind(kind: vscode.SymbolKind): RegionKind {
 	switch (kind) {
 	case vscode.SymbolKind.Class:
@@ -34,6 +37,9 @@ export function mapSymbolKind(kind: vscode.SymbolKind): RegionKind {
 	}
 }
 
+/**
+ * Maps VS Code folding-range categories into filterable region kinds
+ */
 export function mapFoldingRangeKind(kind: vscode.FoldingRangeKind | undefined): RegionKind {
 	if(!kind) {
 		return "unknown";


### PR DESCRIPTION
## Summary

- Add folding-range support for provider-exposed imports, comments, and region markers alongside document-symbol regions
- Merge folding-only ranges into the region tree so relationship filters can combine symbol-backed and folding-range-backed targets
- Expand command/filter coverage for provider fallback cases, mixed symbol and folding-range filters, cache behaviour, malformed symbols, and toggle state
- Refresh nested folding-only descendant depths when their parent later attaches under a symbol
- Add source documentation across the command, model, engine, utility, and extension layers

## Verification

- `npm test`
- 87 passing
- ESLint reports existing generated `src/test/extension.test.js` warnings only, with 0 errors

## Refs

Refs #29
Refs #30
Refs #31
Refs #32
Refs #33
