### PR TITLE
Additive semantic refinement engine

### DIFF
--- a/.github/workflows/sync-project.status.yml
+++ b/.github/workflows/sync-project.status.yml
@@ -1,0 +1,336 @@
+name: Sync project status
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - ready_for_review
+      - closed
+  issues:
+    types:
+      - closed
+      - reopened
+
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
+
+jobs:
+  sync-project-status:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Update project status
+        uses: actions/github-script@v7
+        env:
+          PROJECT_OWNER: ${{ vars.PROJECT_OWNER }}
+          PROJECT_NUMBER: ${{ vars.PROJECT_NUMBER }}
+
+          PROJECT_STATUS_FIELD_NAME: 'Status'
+          DEV_BRANCH: 'dev'
+          MASTER_BRANCH: 'master'
+
+          STATUS_TODO: 'Todo'
+          STATUS_IN_REVIEW: 'In Review'
+          STATUS_STAGED: 'Staged'
+          STATUS_DONE: 'Done'
+        with:
+          github-token: ${{ secrets.PROJECT_AUTOMATION_TOKEN }}
+          script: |
+            const repoOwner = context.repo.owner;
+            const repoName = context.repo.repo;
+
+            const projectOwner = process.env.PROJECT_OWNER || repoOwner;
+            const projectNumber = Number(process.env.PROJECT_NUMBER);
+            const statusFieldName = process.env.PROJECT_STATUS_FIELD_NAME || "Status";
+
+            const DEV_BRANCH = process.env.DEV_BRANCH || "dev";
+            const MASTER_BRANCH = process.env.MASTER_BRANCH || "master";
+
+            const STATUS = {
+              todo: process.env.STATUS_TODO || "Todo",
+              inReview: process.env.STATUS_IN_REVIEW || "In Review",
+              staged: process.env.STATUS_STAGED || "Staged",
+              done: process.env.STATUS_DONE || "Done",
+            };
+
+            function uniq(values) {
+              return [...new Set(values.filter(Boolean))];
+            }
+
+            // Parses same-repo issue refs from PR title/body
+            // Supported examples:
+            //   Refs #29
+            //   Fixes #29
+            //   Closes #29
+            //   Related to #29
+            //   Part of #29
+            //   #29
+            function extractIssueNumbers(text) {
+              if (!text) return [];
+
+              const numbers = new Set();
+              const patterns = [
+                /(?:^|[\s(])(?:close|closes|closed|fix|fixes|fixed|resolve|resolves|resolved|ref|refs)\s*:?\s+#(\d+)/gim,
+                /(?:^|[\s(])(?:related to|part of|addresses)\s*:?\s+#(\d+)/gim,
+                /(?:^|[\s(])#(\d+)/gm,
+              ];
+
+              for (const pattern of patterns) {
+                for (const match of text.matchAll(pattern)) {
+                  numbers.add(Number(match[1]));
+                }
+              }
+
+              return [...numbers];
+            }
+
+            async function getProjectMeta() {
+              const data = await github.graphql(
+                `
+                query($login: String!, $number: Int!) {
+                  user(login: $login) {
+                    projectV2(number: $number) { ...ProjectFields }
+                  }
+                  organization(login: $login) {
+                    projectV2(number: $number) { ...ProjectFields }
+                  }
+                }
+
+                fragment ProjectFields on ProjectV2 {
+                  id
+                  fields(first: 50) {
+                    nodes {
+                      ... on ProjectV2FieldCommon {
+                        id
+                        name
+                      }
+                      ... on ProjectV2SingleSelectField {
+                        id
+                        name
+                        options {
+                          id
+                          name
+                        }
+                      }
+                    }
+                  }
+                }
+                `,
+                {
+                  login: projectOwner,
+                  number: projectNumber,
+                }
+              );
+
+              const project = data.user?.projectV2 ?? data.organization?.projectV2;
+              if (!project) {
+                throw new Error(`Could not find project ${projectOwner} / #${projectNumber}`);
+              }
+
+              const statusField = project.fields.nodes.find(
+                (field) => field.name === statusFieldName && Array.isArray(field.options)
+              );
+
+              if (!statusField) {
+                throw new Error(`Could not find single-select field "${statusFieldName}" on the project`);
+              }
+
+              const optionIds = {};
+              for (const statusName of Object.values(STATUS)) {
+                const option = statusField.options.find((opt) => opt.name === statusName);
+                if (!option) {
+                  throw new Error(`Could not find status option "${statusName}" in "${statusFieldName}"`);
+                }
+                optionIds[statusName] = option.id;
+              }
+
+              return {
+                projectId: project.id,
+                statusFieldId: statusField.id,
+                optionIds,
+              };
+            }
+
+            async function findProjectItem(projectId, contentId) {
+              let after = null;
+
+              while (true) {
+                const data = await github.graphql(
+                  `
+                  query($project: ID!, $after: String) {
+                    node(id: $project) {
+                      ... on ProjectV2 {
+                        items(first: 100, after: $after) {
+                          pageInfo {
+                            hasNextPage
+                            endCursor
+                          }
+                          nodes {
+                            id
+                            content {
+                              __typename
+                              ... on Issue {
+                                id
+                              }
+                            }
+                          }
+                        }
+                      }
+                    }
+                  }
+                  `,
+                  { project: projectId, after }
+                );
+
+                const page = data.node.items;
+                const match = page.nodes.find((node) => node.content?.id === contentId);
+                if (match) return match.id;
+
+                if (!page.pageInfo.hasNextPage) return null;
+                after = page.pageInfo.endCursor;
+              }
+            }
+
+            async function getOrCreateProjectItem(projectId, contentId) {
+              try {
+                const added = await github.graphql(
+                  `
+                  mutation($project: ID!, $content: ID!) {
+                    addProjectV2ItemById(input: { projectId: $project, contentId: $content }) {
+                      item: projectItem {
+                        id
+                      }
+                    }
+                  }
+                  `,
+                  {
+                    project: projectId,
+                    content: contentId,
+                  }
+                );
+
+                return added.addProjectV2ItemById.item.id;
+              } catch (error) {
+                const existingItemId = await findProjectItem(projectId, contentId);
+                if (existingItemId) return existingItemId;
+                throw error;
+              }
+            }
+
+            async function setStatus(projectId, itemId, fieldId, optionId) {
+              await github.graphql(
+                `
+                mutation($project: ID!, $item: ID!, $field: ID!, $option: String!) {
+                  updateProjectV2ItemFieldValue(
+                    input: {
+                      projectId: $project
+                      itemId: $item
+                      fieldId: $field
+                      value: { singleSelectOptionId: $option }
+                    }
+                  ) {
+                    projectV2Item {
+                      id
+                    }
+                  }
+                }
+                `,
+                {
+                  project: projectId,
+                  item: itemId,
+                  field: fieldId,
+                  option: optionId,
+                }
+              );
+            }
+
+            async function loadIssue(issueNumber) {
+              const { data } = await github.rest.issues.get({
+                owner: repoOwner,
+                repo: repoName,
+                issue_number: issueNumber,
+              });
+
+              // Skip PR numbers if someone referenced a PR by mistake
+              if (data.pull_request) return null;
+
+              return {
+                number: data.number,
+                nodeId: data.node_id,
+                title: data.title,
+                state: data.state,
+              };
+            }
+
+            function statusForIssueEvent(action) {
+              if (action === "reopened") return STATUS.todo;
+              if (action === "closed") return STATUS.done;
+              return null;
+            }
+
+            function statusForPullRequestEvent(pr, action) {
+              const base = pr.base.ref;
+              const merged = action === "closed" && pr.merged;
+
+              // This workflow reacts to merged PRs only; it never performs a merge
+              if (merged && base === DEV_BRANCH) return STATUS.staged;
+              if (merged && base === MASTER_BRANCH) return STATUS.done;
+
+              if (
+                base === DEV_BRANCH &&
+                !pr.draft &&
+                ["opened", "reopened", "ready_for_review"].includes(action)
+              ) {
+                return STATUS.inReview;
+              }
+
+              return null;
+            }
+
+            let targetStatus = null;
+            let issueNumbers = [];
+
+            if (context.eventName === "issues") {
+              const issue = context.payload.issue;
+              issueNumbers = [issue.number];
+              targetStatus = statusForIssueEvent(context.payload.action);
+            }
+
+            if (context.eventName === "pull_request") {
+              const pr = context.payload.pull_request;
+              const action = context.payload.action;
+
+              issueNumbers = uniq(
+                extractIssueNumbers(`${pr.title || ""}\n${pr.body || ""}`)
+              );
+              targetStatus = statusForPullRequestEvent(pr, action);
+            }
+
+            if (!targetStatus) {
+              console.log("No matching transition for this event.");
+              return;
+            }
+
+            if (!issueNumbers.length) {
+              console.log("No linked issue numbers found in this event.");
+              return;
+            }
+
+            const { projectId, statusFieldId, optionIds } = await getProjectMeta();
+            const optionId = optionIds[targetStatus];
+
+            for (const issueNumber of issueNumbers) {
+              const issue = await loadIssue(issueNumber);
+              if (!issue) {
+                console.log(`#${issueNumber} is not an issue; skipping.`);
+                continue;
+              }
+
+              const itemId = await getOrCreateProjectItem(projectId, issue.nodeId);
+              await setStatus(projectId, itemId, statusFieldId, optionId);
+
+              console.log(`Set issue #${issue.number} (${issue.title}) -> ${targetStatus}`);
+            }

--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ It primarily uses:
 - folding ranges for extra foldable spans such as comments/imports/regions
 - semantic tokens as a refinement layer, not the main source of structure
 
-Semantic-token refinement is additive. When semantic tokens and their legend are available, Semantic Fold can add a secondary classification to weak symbol regions such as `unknown`, `variable`, or `object` without replacing the original provider kind. If semantic data is missing or fails, the structural symbol and folding-range model is used unchanged.
+Semantic-token refinement is additive and best-effort. When semantic tokens and their legend are available, Semantic Fold can add a secondary classification to weak or ambiguous symbol regions such as `unknown`, `variable`, `object`, `function`, `property`, or `field` without replacing the original provider kind. This can make callable and member filters behave more consistently when language servers disagree about `function` versus `method`, or `property` versus `field`. If semantic data is missing, incomplete, or provider-dependent in a different way, the structural symbol and folding-range model is used unchanged.
+
+Refinement prefers narrower semantic evidence without broadening clear structural categories. For example, a provider-backed `function` may also match `method` when semantic tokens identify it as a method, but a provider-backed `method` is not broadened into `function`.
 
 The extension then filters those regions using one or more constraints and folds only the matching lines.
 
@@ -86,7 +88,7 @@ The normalised semantic category of a region, such as:
 - `comment`
 - `region`
 
-Semantic Fold preserves distinctions such as `struct`, `function`, `method`, `constructor`, `property`, `field`, `variable`, and `object` when the active language extension exposes them through VS Code's document-symbol provider. Provider quality varies by language and extension, so weak providers may report less precise kinds or fall back to unknown categories.
+Semantic Fold preserves distinctions such as `struct`, `function`, `method`, `constructor`, `property`, `field`, `variable`, and `object` when the active language extension exposes them through VS Code's document-symbol provider. Provider quality varies by language and extension, so weak providers may report less precise kinds or fall back to unknown categories. Semantic tokens can refine some of those ambiguous categories, but the result remains provider-dependent rather than a full parser.
 
 ### Symbol depth
 

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Semantic-token refinement is additive and best-effort. When semantic tokens and 
 
 Refinement prefers narrower semantic evidence without broadening clear structural categories. For example, a provider-backed `function` may also match `method` when semantic tokens identify it as a method, but a provider-backed `method` is not broadened into `function`.
 
+If semantic data is disabled or unavailable, Semantic Fold keeps using the structural document-symbol and folding-range model unchanged. Semantic fallback decisions are logged with the `[semanticFold]` prefix through `console.debug` for development visibility.
+
 The extension then filters those regions using one or more constraints and folds only the matching lines.
 
 ### Example
@@ -490,15 +492,15 @@ Create overview keybindings to hide implementation details temporarily.
 
 ## Configuration
 
-Planned settings:
+Available settings:
 
 ```json
 {
-  "semanticFold.useSemanticTokens": true,
-  "semanticFold.preferDocumentSymbols": true,
-  "semanticFold.enableFallbackParsing": false
+  "semanticFold.semanticRefinement.enabled": true
 }
 ```
+
+Set `semanticFold.semanticRefinement.enabled` to `false` to disable semantic-token collection and refinement. When disabled, Semantic Fold uses document symbols and folding ranges only, so unsupported or noisy semantic-token providers cannot change command results.
 
 Future settings may include:
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ It primarily uses:
 - folding ranges for extra foldable spans such as comments/imports/regions
 - semantic tokens as a refinement layer, not the main source of structure
 
+Semantic-token refinement is additive. When semantic tokens and their legend are available, Semantic Fold can add a secondary classification to weak symbol regions such as `unknown`, `variable`, or `object` without replacing the original provider kind. If semantic data is missing or fails, the structural symbol and folding-range model is used unchanged.
+
 The extension then filters those regions using one or more constraints and folds only the matching lines.
 
 ### Example

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semantic-fold",
-  "version": "0.1.2-dev",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semantic-fold",
-      "version": "0.1.2-dev",
+      "version": "0.1.2",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "semantic-fold",
   "displayName": "Semantic Fold",
   "description": "Policy-driven code folding for VS Code",
-  "version": "0.1.2-dev",
+  "version": "0.1.2",
   "engines": {
     "vscode": "^1.111.0"
   },
@@ -52,7 +52,18 @@
         "command": "semanticFold.toggleImports",
         "title": "Semantic Fold: Toggle Imports"
       }
-    ]
+    ],
+    "configuration": {
+      "title": "Semantic Fold",
+      "properties": {
+        "semanticFold.semanticRefinement.enabled": {
+          "type": "boolean",
+          "default": true,
+          "scope": "resource",
+          "description": "Enable semantic-token refinement for weak or ambiguous symbol classifications. When disabled, Semantic Fold uses only document symbols and folding ranges."
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",

--- a/src/engine/filterEngine.ts
+++ b/src/engine/filterEngine.ts
@@ -48,7 +48,7 @@ function matchesIncludedKind(region: RegionNode, filter: CollapseFilter): boolea
 		return true;
 	}
 
-	return filter.kinds.includes(region.kind);
+	return hasAnyRegionKind(region, filter.kinds);
 }
 
 /**
@@ -59,7 +59,7 @@ function matchesExcludedKind(region: RegionNode, filter: CollapseFilter): boolea
 		return false;
 	}
 
-	return filter.excludeKinds.includes(region.kind);
+	return hasAnyRegionKind(region, filter.excludeKinds);
 }
 
 /**
@@ -72,7 +72,7 @@ function matchesParentKind(region: RegionNode, filter: CollapseFilter): boolean 
 
 	const parent = getParent(region);
 
-	return parent !== undefined && filter.parentKinds.includes(parent.kind);
+	return parent !== undefined && hasAnyRegionKind(parent, filter.parentKinds);
 }
 
 /**
@@ -83,7 +83,9 @@ function matchesAncestorKind(region: RegionNode, filter: CollapseFilter): boolea
 		return true;
 	}
 
-	return getAncestors(region).some((ancestor) => filter.ancestorKinds?.includes(ancestor.kind));
+	return getAncestors(region).some((ancestor) => {
+		return filter.ancestorKinds !== undefined && hasAnyRegionKind(ancestor, filter.ancestorKinds);
+	});
 }
 
 /**
@@ -138,4 +140,12 @@ function matchesSymbolDepth(region: RegionNode, filter: CollapseFilter): boolean
 	}
 
 	return true;
+}
+
+/**
+ * Checks structural and semantic classifications as one additive kind set
+ */
+function hasAnyRegionKind(region: RegionNode, kinds: readonly RegionNode["kind"][]): boolean {
+	return kinds.includes(region.kind)
+		|| (region.semanticKind !== undefined && kinds.includes(region.semanticKind));
 }

--- a/src/engine/regionCollector.ts
+++ b/src/engine/regionCollector.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import type { RegionNode } from "../model/region";
 import { getCachedRegions, setCachedRegions } from "../util/cache";
+import { isSemanticRefinementEnabled } from "../util/config";
 import { attachFoldingOnlyNodes } from "./foldingRangeRefiner";
 import { refineWithSemanticTokens } from "./semanticRefiner";
 import { normalizeSymbols } from "./symbolNormaliser";
@@ -49,9 +50,14 @@ export async function getRegions(
 	executeSemanticTokenLegendProvider: SemanticTokenLegendProviderExecutor = defaultSemanticTokenLegendProviderExecutor
 ): Promise<RegionNode[]> {
 	const uri = document.uri.toString();
+	const semanticRefinementEnabled = isSemanticRefinementEnabled(document.uri);
 	const cached = getCachedRegions(uri);
 
-	if(cached && cached.documentVersion === document.version) {
+	if(
+		cached
+		&& cached.documentVersion === document.version
+		&& cached.semanticRefinementEnabled === semanticRefinementEnabled
+	) {
 		return cached.nodes;
 	}
 
@@ -59,20 +65,31 @@ export async function getRegions(
 	const [symbols, foldingRanges, semanticTokens, semanticTokenLegend] = await Promise.all([
 		collectSymbols(document.uri, executeSymbolProvider),
 		collectFoldingRanges(document.uri, executeFoldingRangeProvider),
-		collectSemanticTokens(document.uri, executeSemanticTokenProvider),
-		collectSemanticTokenLegend(document.uri, executeSemanticTokenLegendProvider),
+		semanticRefinementEnabled
+			? collectSemanticTokens(document.uri, executeSemanticTokenProvider)
+			: undefined,
+		semanticRefinementEnabled
+			? collectSemanticTokenLegend(document.uri, executeSemanticTokenLegendProvider)
+			: undefined,
 	]);
-	const nodes = refineWithSemanticTokens(
-		attachFoldingOnlyNodes(normalizeSymbols(symbols), foldingRanges),
-		{
-			document,
-			semanticTokens,
-			semanticTokenLegend,
-		}
-	);
+	
+	const structuralNodes = attachFoldingOnlyNodes(normalizeSymbols(symbols), foldingRanges);
+
+	const nodes = semanticRefinementEnabled
+		? refineWithSemanticTokens(structuralNodes, {
+				document,
+				semanticTokens,
+				semanticTokenLegend,
+			})
+		: structuralNodes;
+
+	if(!semanticRefinementEnabled) {
+		console.debug(`[semanticFold] Semantic refinement disabled for ${uri}`);
+	}
 
 	setCachedRegions(uri, {
 		documentVersion: document.version,
+		semanticRefinementEnabled,
 		nodes,
 	});
 
@@ -116,7 +133,8 @@ async function collectSemanticTokens(
 ): Promise<SemanticTokenProviderResult> {
 	try {
 		return await executeSemanticTokenProvider(uri);
-	} catch {
+	} catch (error) {
+		console.debug(`[semanticFold] Semantic token provider failed for ${uri.toString()}: ${formatError(error)}`);
 		return undefined;
 	}
 }
@@ -130,9 +148,18 @@ async function collectSemanticTokenLegend(
 ): Promise<SemanticTokenLegendProviderResult> {
 	try {
 		return await executeSemanticTokenLegendProvider(uri);
-	} catch {
+	} catch (error) {
+		console.debug(`[semanticFold] Semantic token legend provider failed for ${uri.toString()}: ${formatError(error)}`);
 		return undefined;
 	}
+}
+
+function formatError(error: unknown): string {
+	if(error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
 }
 
 /**

--- a/src/engine/regionCollector.ts
+++ b/src/engine/regionCollector.ts
@@ -2,6 +2,7 @@ import * as vscode from "vscode";
 import type { RegionNode } from "../model/region";
 import { getCachedRegions, setCachedRegions } from "../util/cache";
 import { attachFoldingOnlyNodes } from "./foldingRangeRefiner";
+import { refineWithSemanticTokens } from "./semanticRefiner";
 import { normalizeSymbols } from "./symbolNormaliser";
 
 /**
@@ -14,6 +15,8 @@ type SymbolProviderResult =
 	| undefined;
 
 type FoldingRangeProviderResult = vscode.FoldingRange[] | null | undefined;
+type SemanticTokenProviderResult = vscode.SemanticTokens | null | undefined;
+type SemanticTokenLegendProviderResult = vscode.SemanticTokensLegend | null | undefined;
 
 /**
  * Injectable document-symbol provider executor for tests and command isolation
@@ -26,12 +29,24 @@ export type SymbolProviderExecutor = (uri: vscode.Uri) => Thenable<SymbolProvide
 export type FoldingRangeProviderExecutor = (uri: vscode.Uri) => Thenable<FoldingRangeProviderResult>;
 
 /**
+ * Injectable semantic-token provider executor for tests and command isolation
+ */
+export type SemanticTokenProviderExecutor = (uri: vscode.Uri) => Thenable<SemanticTokenProviderResult>;
+
+/**
+ * Injectable semantic-token legend provider executor for tests and command isolation
+ */
+export type SemanticTokenLegendProviderExecutor = (uri: vscode.Uri) => Thenable<SemanticTokenLegendProviderResult>;
+
+/**
  * Collects, normalises, merges, and caches provider-backed regions for a document
  */
 export async function getRegions(
 	document: vscode.TextDocument,
 	executeSymbolProvider: SymbolProviderExecutor = defaultSymbolProviderExecutor,
-	executeFoldingRangeProvider: FoldingRangeProviderExecutor = defaultFoldingRangeProviderExecutor
+	executeFoldingRangeProvider: FoldingRangeProviderExecutor = defaultFoldingRangeProviderExecutor,
+	executeSemanticTokenProvider: SemanticTokenProviderExecutor = defaultSemanticTokenProviderExecutor,
+	executeSemanticTokenLegendProvider: SemanticTokenLegendProviderExecutor = defaultSemanticTokenLegendProviderExecutor
 ): Promise<RegionNode[]> {
 	const uri = document.uri.toString();
 	const cached = getCachedRegions(uri);
@@ -40,12 +55,21 @@ export async function getRegions(
 		return cached.nodes;
 	}
 
-	// Symbols and folding ranges come from separate VS Code providers
-	const [symbols, foldingRanges] = await Promise.all([
+	// Structural and semantic data come from separate VS Code providers
+	const [symbols, foldingRanges, semanticTokens, semanticTokenLegend] = await Promise.all([
 		collectSymbols(document.uri, executeSymbolProvider),
 		collectFoldingRanges(document.uri, executeFoldingRangeProvider),
+		collectSemanticTokens(document.uri, executeSemanticTokenProvider),
+		collectSemanticTokenLegend(document.uri, executeSemanticTokenLegendProvider),
 	]);
-	const nodes = attachFoldingOnlyNodes(normalizeSymbols(symbols), foldingRanges);
+	const nodes = refineWithSemanticTokens(
+		attachFoldingOnlyNodes(normalizeSymbols(symbols), foldingRanges),
+		{
+			document,
+			semanticTokens,
+			semanticTokenLegend,
+		}
+	);
 
 	setCachedRegions(uri, {
 		documentVersion: document.version,
@@ -84,6 +108,34 @@ async function collectFoldingRanges(
 }
 
 /**
+ * Converts semantic-token failures into absent semantic data
+ */
+async function collectSemanticTokens(
+	uri: vscode.Uri,
+	executeSemanticTokenProvider: SemanticTokenProviderExecutor
+): Promise<SemanticTokenProviderResult> {
+	try {
+		return await executeSemanticTokenProvider(uri);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
+ * Converts semantic-token legend failures into absent semantic data
+ */
+async function collectSemanticTokenLegend(
+	uri: vscode.Uri,
+	executeSemanticTokenLegendProvider: SemanticTokenLegendProviderExecutor
+): Promise<SemanticTokenLegendProviderResult> {
+	try {
+		return await executeSemanticTokenLegendProvider(uri);
+	} catch {
+		return undefined;
+	}
+}
+
+/**
  * Production bridge to VS Code's document-symbol provider command
  */
 function defaultSymbolProviderExecutor(uri: vscode.Uri): Thenable<SymbolProviderResult> {
@@ -99,6 +151,26 @@ function defaultSymbolProviderExecutor(uri: vscode.Uri): Thenable<SymbolProvider
 function defaultFoldingRangeProviderExecutor(uri: vscode.Uri): Thenable<FoldingRangeProviderResult> {
 	return vscode.commands.executeCommand<FoldingRangeProviderResult>(
 		"vscode.executeFoldingRangeProvider",
+		uri
+	);
+}
+
+/**
+ * Production bridge to VS Code's document semantic-token command
+ */
+function defaultSemanticTokenProviderExecutor(uri: vscode.Uri): Thenable<SemanticTokenProviderResult> {
+	return vscode.commands.executeCommand<SemanticTokenProviderResult>(
+		"vscode.provideDocumentSemanticTokens",
+		uri
+	);
+}
+
+/**
+ * Production bridge to VS Code's semantic-token legend command
+ */
+function defaultSemanticTokenLegendProviderExecutor(uri: vscode.Uri): Thenable<SemanticTokenLegendProviderResult> {
+	return vscode.commands.executeCommand<SemanticTokenLegendProviderResult>(
+		"vscode.provideDocumentSemanticTokensLegend",
 		uri
 	);
 }

--- a/src/engine/semanticRefiner.ts
+++ b/src/engine/semanticRefiner.ts
@@ -17,7 +17,6 @@ interface DecodedSemanticToken {
 	tokenType: string;
 }
 
-const weakRegionKinds = new Set<RegionKind>(["unknown", "object", "variable"]);
 const semanticTokenKinds = new Map<string, RegionKind>([
 	["class", "class"],
 	["struct", "struct"],
@@ -27,7 +26,22 @@ const semanticTokenKinds = new Map<string, RegionKind>([
 	["function", "function"],
 	["method", "method"],
 	["property", "property"],
+	["field", "field"],
 	["variable", "variable"],
+]);
+
+const broadSemanticRegionKinds   = new Set<RegionKind>(["unknown", "object", "variable"]);
+
+/*
+ * Refinement moves from broader or commonly ambiguous provider categories toward
+ * narrower semantic evidence. A provider-backed method stays a method, even if a
+ * token provider calls it a function, because function filters should not expand
+ * to every method unless the structural provider was already broad
+ */
+const ambiguousRegionRefinements = new Map<RegionKind, ReadonlySet<RegionKind>>([
+	["function", new Set<RegionKind>(["method"])],
+	["property", new Set<RegionKind>(["field"])],
+	["field", new Set<RegionKind>(["property"])],
 ]);
 
 /**
@@ -104,7 +118,7 @@ function findSemanticKindForRegion(
 	semanticTokens: readonly DecodedSemanticToken[],
 	document: vscode.TextDocument
 ): RegionKind | undefined {
-	if(region.source === "foldingRange" || !weakRegionKinds.has(region.kind)) {
+	if(region.source === "foldingRange") {
 		return undefined;
 	}
 
@@ -115,7 +129,7 @@ function findSemanticKindForRegion(
 
 		const semanticKind = semanticTokenKinds.get(semanticToken.tokenType);
 
-		if(semanticKind === undefined) {
+		if(semanticKind === undefined || !canRefineRegionKind(region.kind, semanticKind)) {
 			continue;
 		}
 
@@ -125,6 +139,18 @@ function findSemanticKindForRegion(
 	}
 
 	return undefined;
+}
+
+function canRefineRegionKind(regionKind: RegionKind, semanticKind: RegionKind): boolean {
+	if(regionKind === semanticKind) {
+		return false;
+	}
+
+	if(broadSemanticRegionKinds.has(regionKind)) {
+		return true;
+	}
+
+	return ambiguousRegionRefinements.get(regionKind)?.has(semanticKind) ?? false;
 }
 
 function getTokenText(document: vscode.TextDocument, semanticToken: DecodedSemanticToken): string | undefined {

--- a/src/engine/semanticRefiner.ts
+++ b/src/engine/semanticRefiner.ts
@@ -1,11 +1,24 @@
+import * as vscode from "vscode";
 import type { RegionNode } from "../model/region";
 
 /**
- * Placeholder for future semantic-token enrichment
- *
- * The current provider-backed model already carries the categories that this
- * phase can safely support, so the refiner intentionally returns the tree as-is
+ * Semantic-token data made available to refinement without coupling it to collection
  */
-export function refineWithSemanticTokens(rootNodes: RegionNode[]): RegionNode[] {
-    return rootNodes;
+export interface SemanticTokenRefinementContext {
+	document: vscode.TextDocument;
+	semanticTokens: vscode.SemanticTokens | null | undefined;
+	semanticTokenLegend: vscode.SemanticTokensLegend | null | undefined;
+}
+
+/**
+ * Placeholder for semantic-token enrichment
+ *
+ * Collection can pass semantic data here, while unavailable or unused semantic
+ * data keeps the provider-backed tree unchanged
+ */
+export function refineWithSemanticTokens(
+	rootNodes: RegionNode[],
+	_context?: SemanticTokenRefinementContext
+): RegionNode[] {
+	return rootNodes;
 }

--- a/src/engine/semanticRefiner.ts
+++ b/src/engine/semanticRefiner.ts
@@ -54,7 +54,20 @@ export function refineWithSemanticTokens(
 	rootNodes: RegionNode[],
 	context?: SemanticTokenRefinementContext
 ): RegionNode[] {
-	if(!context || !isSemanticTokens(context.semanticTokens) || !isSemanticTokenLegend(context.semanticTokenLegend)) {
+	if(!context) {
+		console.debug("[semanticFold] Semantic refinement skipped because no semantic context was provided");
+		return rootNodes;
+	}
+
+	const uri = context.document.uri.toString();
+
+	if(!isSemanticTokens(context.semanticTokens)) {
+		console.debug(`[semanticFold] Semantic refinement skipped for ${uri}: semantic tokens unavailable`);
+		return rootNodes;
+	}
+
+	if(!isSemanticTokenLegend(context.semanticTokenLegend)) {
+		console.debug(`[semanticFold] Semantic refinement skipped for ${uri}: semantic token legend unavailable`);
 		return rootNodes;
 	}
 
@@ -62,6 +75,7 @@ export function refineWithSemanticTokens(
 		const semanticTokens = decodeSemanticTokens(context.semanticTokens, context.semanticTokenLegend);
 
 		if(semanticTokens.length === 0) {
+			console.debug(`[semanticFold] Semantic refinement skipped for ${uri}: no semantic tokens returned`);
 			return rootNodes;
 		}
 
@@ -72,7 +86,8 @@ export function refineWithSemanticTokens(
 				region.semanticKind = semanticKind;
 			}
 		}
-	} catch {
+	} catch (error) {
+		console.debug(`[semanticFold] Semantic refinement failed for ${uri}: ${formatError(error)}`);
 		return rootNodes;
 	}
 
@@ -200,4 +215,12 @@ function isSemanticTokenLegend(value: unknown): value is vscode.SemanticTokensLe
 	return semanticTokenLegend !== undefined
 		&& semanticTokenLegend !== null
 		&& Array.isArray(semanticTokenLegend.tokenTypes);
+}
+
+function formatError(error: unknown): string {
+	if(error instanceof Error) {
+		return error.message;
+	}
+
+	return String(error);
 }

--- a/src/engine/semanticRefiner.ts
+++ b/src/engine/semanticRefiner.ts
@@ -1,8 +1,8 @@
 import * as vscode from "vscode";
-import type { RegionNode } from "../model/region";
+import type { RegionKind, RegionNode } from "../model/region";
 
 /**
- * Semantic-token data made available to refinement without coupling it to collection
+ * Semantic-token data needed to refine structural regions
  */
 export interface SemanticTokenRefinementContext {
 	document: vscode.TextDocument;
@@ -10,15 +10,168 @@ export interface SemanticTokenRefinementContext {
 	semanticTokenLegend: vscode.SemanticTokensLegend | null | undefined;
 }
 
+interface DecodedSemanticToken {
+	line: number;
+	startCharacter: number;
+	length: number;
+	tokenType: string;
+}
+
+const weakRegionKinds = new Set<RegionKind>(["unknown", "object", "variable"]);
+const semanticTokenKinds = new Map<string, RegionKind>([
+	["class", "class"],
+	["struct", "struct"],
+	["interface", "interface"],
+	["enum", "enum"],
+	["namespace", "namespace"],
+	["function", "function"],
+	["method", "method"],
+	["property", "property"],
+	["variable", "variable"],
+]);
+
 /**
- * Placeholder for semantic-token enrichment
+ * Adds semantic-token classifications to weak symbol regions when available
  *
- * Collection can pass semantic data here, while unavailable or unused semantic
- * data keeps the provider-backed tree unchanged
+ * The original structural kind is left intact so semantic data can only add a
+ * matchable classification, never replace the provider-backed model
  */
 export function refineWithSemanticTokens(
 	rootNodes: RegionNode[],
-	_context?: SemanticTokenRefinementContext
+	context?: SemanticTokenRefinementContext
 ): RegionNode[] {
+	if(!context || !isSemanticTokens(context.semanticTokens) || !isSemanticTokenLegend(context.semanticTokenLegend)) {
+		return rootNodes;
+	}
+
+	try {
+		const semanticTokens = decodeSemanticTokens(context.semanticTokens, context.semanticTokenLegend);
+
+		if(semanticTokens.length === 0) {
+			return rootNodes;
+		}
+
+		for(const region of flattenRegionTree(rootNodes)) {
+			const semanticKind = findSemanticKindForRegion(region, semanticTokens, context.document);
+
+			if(semanticKind !== undefined && semanticKind !== region.kind) {
+				region.semanticKind = semanticKind;
+			}
+		}
+	} catch {
+		return rootNodes;
+	}
+
 	return rootNodes;
+}
+
+function decodeSemanticTokens(
+	semanticTokens: vscode.SemanticTokens,
+	semanticTokenLegend: vscode.SemanticTokensLegend
+): DecodedSemanticToken[] {
+	const decodedTokens: DecodedSemanticToken[] = [];
+	let line = 0;
+	let startCharacter = 0;
+
+	for(let index = 0; index + 4 < semanticTokens.data.length; index += 5) {
+		const deltaLine = semanticTokens.data[index];
+		const deltaStartCharacter = semanticTokens.data[index + 1];
+		const length = semanticTokens.data[index + 2];
+		const tokenTypeIndex = semanticTokens.data[index + 3];
+
+		line += deltaLine;
+		startCharacter = deltaLine === 0
+			? startCharacter + deltaStartCharacter
+			: deltaStartCharacter;
+
+		const tokenType = semanticTokenLegend.tokenTypes[tokenTypeIndex];
+
+		if(tokenType !== undefined && length > 0) {
+			decodedTokens.push({
+				line,
+				startCharacter,
+				length,
+				tokenType,
+			});
+		}
+	}
+
+	return decodedTokens;
+}
+
+function findSemanticKindForRegion(
+	region: RegionNode,
+	semanticTokens: readonly DecodedSemanticToken[],
+	document: vscode.TextDocument
+): RegionKind | undefined {
+	if(region.source === "foldingRange" || !weakRegionKinds.has(region.kind)) {
+		return undefined;
+	}
+
+	for(const semanticToken of semanticTokens) {
+		if(semanticToken.line !== region.selectionLine) {
+			continue;
+		}
+
+		const semanticKind = semanticTokenKinds.get(semanticToken.tokenType);
+
+		if(semanticKind === undefined) {
+			continue;
+		}
+
+		if(region.name === undefined || getTokenText(document, semanticToken) === region.name) {
+			return semanticKind;
+		}
+	}
+
+	return undefined;
+}
+
+function getTokenText(document: vscode.TextDocument, semanticToken: DecodedSemanticToken): string | undefined {
+	try {
+		const line = document.lineAt(semanticToken.line).text;
+		const endCharacter = semanticToken.startCharacter + semanticToken.length;
+
+		if(semanticToken.startCharacter < 0 || endCharacter > line.length) {
+			return undefined;
+		}
+
+		return line.slice(semanticToken.startCharacter, endCharacter);
+	} catch {
+		return undefined;
+	}
+}
+
+function flattenRegionTree(rootNodes: readonly RegionNode[]): RegionNode[] {
+	const regions: RegionNode[] = [];
+
+	for(const rootNode of rootNodes) {
+		appendRegion(rootNode, regions);
+	}
+
+	return regions;
+}
+
+function appendRegion(region: RegionNode, regions: RegionNode[]): void {
+	regions.push(region);
+
+	for(const child of region.children) {
+		appendRegion(child, regions);
+	}
+}
+
+function isSemanticTokens(value: unknown): value is vscode.SemanticTokens {
+	const semanticTokens = value as Partial<vscode.SemanticTokens> | null | undefined;
+
+	return semanticTokens !== undefined
+		&& semanticTokens !== null
+		&& semanticTokens.data instanceof Uint32Array;
+}
+
+function isSemanticTokenLegend(value: unknown): value is vscode.SemanticTokensLegend {
+	const semanticTokenLegend = value as Partial<vscode.SemanticTokensLegend> | null | undefined;
+
+	return semanticTokenLegend !== undefined
+		&& semanticTokenLegend !== null
+		&& Array.isArray(semanticTokenLegend.tokenTypes);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,8 @@ import {
 } from "./commands/collapse";
 import { expandCommand } from "./commands/expand";
 import { toggleCommand } from "./commands/toggle";
-import { invalidateRegionCache, invalidateRegionCacheDebounced } from "./util/cache";
+import { clearRegionCache, invalidateRegionCache, invalidateRegionCacheDebounced } from "./util/cache";
+import { SEMANTIC_REFINEMENT_ENABLED_SETTING } from "./util/config";
 
 /**
  * Delay used to avoid rebuilding regions for every keystroke
@@ -54,7 +55,13 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.workspace.onDidCloseTextDocument((document) => {
 			const documentUri = document.uri.toString();
 			invalidateRegionCache(documentUri);
-		})
+		}),
+			vscode.workspace.onDidChangeConfiguration((event) => {
+				if(event.affectsConfiguration(SEMANTIC_REFINEMENT_ENABLED_SETTING)) {
+					console.debug("[semanticFold] Semantic refinement setting changed, clearing region cache");
+					clearRegionCache();
+				}
+			})
 	);
 }
 

--- a/src/model/region.ts
+++ b/src/model/region.ts
@@ -48,6 +48,11 @@ export interface RegionNode {
 	kind: RegionKind;
 
 	/**
+	 * Optional semantic-token-backed category added without replacing the provider kind
+	 */
+	semanticKind?: RegionKind;
+
+	/**
 	 * Inclusive zero-based start line for the full provider range
 	 */
 	rangeStartLine: number;

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -105,10 +105,11 @@ suite("Document Region Collection", () => {
 		assert.strictEqual(requestedSemanticTokenUri?.toString(), document.uri.toString());
 		assert.strictEqual(requestedSemanticLegendUri?.toString(), document.uri.toString());
 		assert.strictEqual(regions[0].kind, "unknown");
+		assert.strictEqual(regions[0].semanticKind, "function");
 		assert.deepStrictEqual(
 			collectSelectionLines(selectFoldableRegions({
 				filter: {
-					kinds: ["unknown"],
+					kinds: ["function"],
 				},
 			}, regions)),
 			[0]
@@ -167,6 +168,7 @@ suite("Document Region Collection", () => {
 
 		assert.strictEqual(regions.length, 1);
 		assert.strictEqual(regions[0].kind, "unknown");
+		assert.strictEqual(regions[0].semanticKind, undefined);
 		assert.deepStrictEqual(
 			collectSelectionLines(selectFoldableRegions({
 				filter: {
@@ -1492,6 +1494,109 @@ suite("Semantic Token Refinement", () => {
 		const regions = createMixedSymbolAndFoldingFixture();
 
 		assert.strictEqual(refineWithSemanticTokens(regions), regions);
+	});
+
+	test("adds semantic kinds to weak symbol regions without replacing structural kinds", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "const handler = () => {\n\treturn true;\n}\n\nfunction run() {\n\treturn true;\n}\n",
+			language: "typescript",
+		});
+		const weakSymbol = createSymbol("handler", 999 as vscode.SymbolKind, 0, 2);
+		const strongSymbol = createSymbol("run", vscode.SymbolKind.Function, 4, 6);
+		const regions = normalizeSymbols([weakSymbol, strongSymbol]);
+		const semanticTokenLegend = new vscode.SemanticTokensLegend(["function", "property"]);
+		const semanticTokens = createSemanticTokens([
+			{
+				line: 0,
+				startCharacter: 6,
+				length: 7,
+				tokenType: 0,
+			},
+			{
+				line: 4,
+				startCharacter: 9,
+				length: 3,
+				tokenType: 1,
+			},
+		]);
+
+		const refinedRegions = refineWithSemanticTokens(regions, {
+			document,
+			semanticTokens,
+			semanticTokenLegend,
+		});
+
+		assert.strictEqual(refinedRegions, regions);
+		assert.strictEqual(regions[0].kind, "unknown");
+		assert.strictEqual(regions[0].semanticKind, "function");
+		assert.strictEqual(regions[1].kind, "function");
+		assert.strictEqual(regions[1].semanticKind, undefined);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+			}).map((region) => region.name),
+			["handler", "run"]
+		);
+	});
+
+	test("ignores semantic tokens whose text does not match the region name", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "const other = () => {\n\treturn true;\n}\n",
+			language: "typescript",
+		});
+		const weakSymbol = createSymbol("handler", 999 as vscode.SymbolKind, 0, 2);
+		const regions = normalizeSymbols([weakSymbol]);
+
+		refineWithSemanticTokens(regions, {
+			document,
+			semanticTokens: createSemanticTokens([{
+				line: 0,
+				startCharacter: 6,
+				length: 5,
+				tokenType: 0,
+			}]),
+			semanticTokenLegend: new vscode.SemanticTokensLegend(["function"]),
+		});
+
+		assert.strictEqual(regions[0].semanticKind, undefined);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+			}),
+			[]
+		);
+	});
+
+	test("uses semantic parent classifications in relationship filters", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "class Example {\n\trun() {\n\t\treturn true;\n\t}\n}\n",
+			language: "typescript",
+		});
+		const classSymbol = createSymbol("Example", 999 as vscode.SymbolKind, 0, 4);
+		const methodSymbol = createSymbol("run", vscode.SymbolKind.Method, 1, 3);
+		classSymbol.children.push(methodSymbol);
+		const regions = normalizeSymbols([classSymbol]);
+
+		refineWithSemanticTokens(regions, {
+			document,
+			semanticTokens: createSemanticTokens([{
+				line: 0,
+				startCharacter: 6,
+				length: 7,
+				tokenType: 0,
+			}]),
+			semanticTokenLegend: new vscode.SemanticTokensLegend(["class"]),
+		});
+
+		assert.strictEqual(regions[0].kind, "unknown");
+		assert.strictEqual(regions[0].semanticKind, "class");
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["run"]
+		);
 	});
 });
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -72,6 +72,49 @@ suite("Document Region Collection", () => {
 		);
 	});
 
+	test("requests semantic tokens and legend for the supplied document uri", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "const handler = () => {\n\treturn true;\n}\n",
+			language: "typescript",
+		});
+		const weakSymbol = createSymbol("handler", 999 as vscode.SymbolKind, 0, 2);
+		const semanticTokens = createSemanticTokens([{
+			line: 0,
+			startCharacter: 6,
+			length: 7,
+			tokenType: 0,
+		}]);
+		const semanticTokenLegend = new vscode.SemanticTokensLegend(["function"]);
+		let requestedSemanticTokenUri: vscode.Uri | undefined;
+		let requestedSemanticLegendUri: vscode.Uri | undefined;
+
+		const regions = await getRegions(document, async () => {
+			return [weakSymbol];
+		}, async () => {
+			return [];
+		}, async (uri) => {
+			requestedSemanticTokenUri = uri;
+
+			return semanticTokens;
+		}, async (uri) => {
+			requestedSemanticLegendUri = uri;
+
+			return semanticTokenLegend;
+		});
+
+		assert.strictEqual(requestedSemanticTokenUri?.toString(), document.uri.toString());
+		assert.strictEqual(requestedSemanticLegendUri?.toString(), document.uri.toString());
+		assert.strictEqual(regions[0].kind, "unknown");
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["unknown"],
+				},
+			}, regions)),
+			[0]
+		);
+	});
+
 	test("returns an empty region tree when the provider fails", async () => {
 		const document = await vscode.workspace.openTextDocument({
 			content: "class Example {}\n",
@@ -103,6 +146,35 @@ suite("Document Region Collection", () => {
 		assert.strictEqual(regions.length, 1);
 		assert.strictEqual(regions[0].name, "Example");
 		assert.strictEqual(regions[0].source, "documentSymbol");
+	});
+
+	test("keeps structural regions when semantic tokens are unavailable", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "const handler = () => {\n\treturn true;\n}\n",
+			language: "typescript",
+		});
+		const weakSymbol = createSymbol("handler", 999 as vscode.SymbolKind, 0, 2);
+
+		const regions = await getRegions(document, async () => {
+			return [weakSymbol];
+		}, async () => {
+			return [];
+		}, async () => {
+			throw new Error("semantic provider failed");
+		}, async () => {
+			return new vscode.SemanticTokensLegend(["function"]);
+		});
+
+		assert.strictEqual(regions.length, 1);
+		assert.strictEqual(regions[0].kind, "unknown");
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: ["unknown"],
+				},
+			}, regions)),
+			[0]
+		);
 	});
 
 	test("keeps folding ranges when symbols are unavailable", async () => {
@@ -1416,7 +1488,7 @@ suite("Region Filtering", () => {
 });
 
 suite("Semantic Token Refinement", () => {
-	test("returns the provider-backed region tree unchanged until semantic refinement is implemented", () => {
+	test("returns the provider-backed region tree unchanged when semantic data is missing", () => {
 		const regions = createMixedSymbolAndFoldingFixture();
 
 		assert.strictEqual(refineWithSemanticTokens(regions), regions);
@@ -1887,6 +1959,38 @@ function createSymbolInformation(
 		"",
 		new vscode.Location(uri, new vscode.Range(startLine, 0, endLine, 1))
 	);
+}
+
+function createSemanticTokens(tokens: Array<{
+	line: number;
+	startCharacter: number;
+	length: number;
+	tokenType: number;
+	tokenModifiers?: number;
+}>): vscode.SemanticTokens {
+	const data: number[] = [];
+	let previousLine = 0;
+	let previousStartCharacter = 0;
+
+	for(const token of tokens) {
+		const deltaLine = token.line - previousLine;
+		const deltaStartCharacter = deltaLine === 0
+			? token.startCharacter - previousStartCharacter
+			: token.startCharacter;
+
+		data.push(
+			deltaLine,
+			deltaStartCharacter,
+			token.length,
+			token.tokenType,
+			token.tokenModifiers ?? 0
+		);
+
+		previousLine = token.line;
+		previousStartCharacter = token.startCharacter;
+	}
+
+	return new vscode.SemanticTokens(new Uint32Array(data));
 }
 
 function createFilterFixture(): ReturnType<typeof normalizeSymbols> {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -39,6 +39,15 @@ suite("Semantic Fold Foundation", () => {
 		assert.ok(commands.includes("semanticFold.toggleFunctionsInVariables"));
 		assert.ok(commands.includes("semanticFold.toggleImports"));
 	});
+
+	test("contributes semantic refinement configuration", () => {
+		const extension = getSemanticFoldExtension();
+		const setting = extension.packageJSON.contributes.configuration.properties["semanticFold.semanticRefinement.enabled"];
+
+		assert.strictEqual(setting.type, "boolean");
+		assert.strictEqual(setting.default, true);
+		assert.strictEqual(setting.scope, "resource");
+	});
 });
 
 suite("Document Region Collection", () => {
@@ -114,6 +123,52 @@ suite("Document Region Collection", () => {
 			}, regions)),
 			[0]
 		);
+	});
+
+	test("skips semantic token collection when semantic refinement is disabled", async () => {
+		await withSemanticRefinementEnabled(false, async () => {
+			clearRegionCache();
+
+			const document = await vscode.workspace.openTextDocument({
+				content: "const handler = () => {\n\treturn true;\n}\n",
+				language: "typescript",
+			});
+			const weakSymbol = createSymbol("handler", 999 as vscode.SymbolKind, 0, 2);
+			let semanticTokenCallCount = 0;
+			let semanticLegendCallCount = 0;
+
+			const regions = await getRegions(document, async () => {
+				return [weakSymbol];
+			}, async () => {
+				return [];
+			}, async () => {
+				semanticTokenCallCount++;
+
+				return createSemanticTokens([{
+					line: 0,
+					startCharacter: 6,
+					length: 7,
+					tokenType: 0,
+				}]);
+			}, async () => {
+				semanticLegendCallCount++;
+
+				return new vscode.SemanticTokensLegend(["function"]);
+			});
+
+			assert.strictEqual(semanticTokenCallCount, 0);
+			assert.strictEqual(semanticLegendCallCount, 0);
+			assert.strictEqual(regions[0].kind, "unknown");
+			assert.strictEqual(regions[0].semanticKind, undefined);
+			assert.deepStrictEqual(
+				collectSelectionLines(selectFoldableRegions({
+					filter: {
+						kinds: ["unknown"],
+					},
+				}, regions)),
+				[0]
+			);
+		});
 	});
 
 	test("returns an empty region tree when the provider fails", async () => {
@@ -1496,6 +1551,29 @@ suite("Semantic Token Refinement", () => {
 		assert.strictEqual(refineWithSemanticTokens(regions), regions);
 	});
 
+	test("keeps structural regions when semantic token legend is missing", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "const handler = () => {\n\treturn true;\n}\n",
+			language: "typescript",
+		});
+		const weakSymbol = createSymbol("handler", 999 as vscode.SymbolKind, 0, 2);
+		const regions = normalizeSymbols([weakSymbol]);
+
+		const refinedRegions = refineWithSemanticTokens(regions, {
+			document,
+			semanticTokens: createSemanticTokens([{
+				line: 0,
+				startCharacter: 6,
+				length: 7,
+				tokenType: 0,
+			}]),
+			semanticTokenLegend: undefined,
+		});
+
+		assert.strictEqual(refinedRegions, regions);
+		assert.strictEqual(regions[0].semanticKind, undefined);
+	});
+
 	test("adds semantic kinds to weak symbol regions without replacing structural kinds", async () => {
 		const document = await vscode.workspace.openTextDocument({
 			content: "const handler = () => {\n\treturn true;\n}\n\nfunction run() {\n\treturn true;\n}\n",
@@ -2327,14 +2405,34 @@ interface ExecutedCommand {
 	selectionLines: number[];
 }
 
-async function activateExtension(): Promise<void> {
+function getSemanticFoldExtension(): vscode.Extension<unknown> {
 	const extension = vscode.extensions.all.find((candidate) => {
 		return candidate.packageJSON.name === "semantic-fold";
 	});
 
 	assert.ok(extension);
 
+	return extension;
+}
+
+async function activateExtension(): Promise<void> {
+	const extension = getSemanticFoldExtension();
+
 	await extension.activate();
+}
+
+async function withSemanticRefinementEnabled(enabled: boolean, callback: () => Promise<void>): Promise<void> {
+	const configuration = vscode.workspace.getConfiguration("semanticFold.semanticRefinement");
+	const inspectedValue = configuration.inspect<boolean>("enabled");
+
+	await configuration.update("enabled", enabled, vscode.ConfigurationTarget.Global);
+
+	try {
+		await callback();
+	} finally {
+		await configuration.update("enabled", inspectedValue?.globalValue, vscode.ConfigurationTarget.Global);
+		clearRegionCache();
+	}
 }
 
 async function delay(delayMs: number): Promise<void> {

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1539,6 +1539,106 @@ suite("Semantic Token Refinement", () => {
 		);
 	});
 
+	test("refines ambiguous callable symbols without changing clear method symbols", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "class Example {\n\trun() {\n\t\treturn true;\n\t}\n\tstop() {\n\t\treturn true;\n\t}\n}\n",
+			language: "typescript",
+		});
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 7);
+		const functionSymbol = createSymbol("run", vscode.SymbolKind.Function, 1, 3);
+		const methodSymbol = createSymbol("stop", vscode.SymbolKind.Method, 4, 6);
+		classSymbol.children.push(functionSymbol, methodSymbol);
+		const regions = normalizeSymbols([classSymbol]);
+
+		refineWithSemanticTokens(regions, {
+			document,
+			semanticTokens: createSemanticTokens([
+				{
+					line: 1,
+					startCharacter: 1,
+					length: 3,
+					tokenType: 0,
+				},
+				{
+					line: 4,
+					startCharacter: 1,
+					length: 4,
+					tokenType: 1,
+				},
+			]),
+			semanticTokenLegend: new vscode.SemanticTokensLegend(["method", "function"]),
+		});
+
+		assert.strictEqual(regions[0].children[0].kind, "function");
+		assert.strictEqual(regions[0].children[0].semanticKind, "method");
+		assert.strictEqual(regions[0].children[1].kind, "method");
+		assert.strictEqual(regions[0].children[1].semanticKind, undefined);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["method"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["run", "stop"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["function"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["run"]
+		);
+	});
+
+	test("refines property and field ambiguity in both filter directions", async () => {
+		const document = await vscode.workspace.openTextDocument({
+			content: "class Example {\n\tcount = 1;\n\ttitle = \"\";\n}\n",
+			language: "typescript",
+		});
+		const classSymbol = createSymbol("Example", vscode.SymbolKind.Class, 0, 3);
+		const propertySymbol = createSymbol("count", vscode.SymbolKind.Property, 1, 1);
+		const fieldSymbol = createSymbol("title", vscode.SymbolKind.Field, 2, 2);
+		classSymbol.children.push(propertySymbol, fieldSymbol);
+		const regions = normalizeSymbols([classSymbol]);
+
+		refineWithSemanticTokens(regions, {
+			document,
+			semanticTokens: createSemanticTokens([
+				{
+					line: 1,
+					startCharacter: 1,
+					length: 5,
+					tokenType: 0,
+				},
+				{
+					line: 2,
+					startCharacter: 1,
+					length: 5,
+					tokenType: 1,
+				},
+			]),
+			semanticTokenLegend: new vscode.SemanticTokensLegend(["field", "property"]),
+		});
+
+		assert.strictEqual(regions[0].children[0].kind, "property");
+		assert.strictEqual(regions[0].children[0].semanticKind, "field");
+		assert.strictEqual(regions[0].children[1].kind, "field");
+		assert.strictEqual(regions[0].children[1].semanticKind, "property");
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["field"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["count", "title"]
+		);
+		assert.deepStrictEqual(
+			filterRegions(regions, {
+				kinds: ["property"],
+				parentKinds: ["class"],
+			}).map((region) => region.name),
+			["count", "title"]
+		);
+	});
+
 	test("ignores semantic tokens whose text does not match the region name", async () => {
 		const document = await vscode.workspace.openTextDocument({
 			content: "const other = () => {\n\treturn true;\n}\n",

--- a/src/util/cache.ts
+++ b/src/util/cache.ts
@@ -5,6 +5,7 @@ import type { RegionNode } from "../model/region";
  */
 export interface CachedRegions {
 	documentVersion: number;
+	semanticRefinementEnabled?: boolean;
 	nodes: RegionNode[];
 }
 

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -1,0 +1,14 @@
+import * as vscode from "vscode";
+
+export const SEMANTIC_REFINEMENT_ENABLED_SETTING = "semanticFold.semanticRefinement.enabled";
+
+const SEMANTIC_REFINEMENT_SECTION = "semanticFold.semanticRefinement";
+
+/**
+ * Reads whether semantic-token refinement should participate for a resource
+ */
+export function isSemanticRefinementEnabled(resource?: vscode.Uri): boolean {
+	return vscode.workspace
+		.getConfiguration(SEMANTIC_REFINEMENT_SECTION, resource)
+		.get<boolean>("enabled", true);
+}


### PR DESCRIPTION
- Collect semantic token data.
- Add additive semantic classifications.
- Add best-effort semantic refinement rules for function/method and property/field
provider differences while preserving structural classifications.
- Cover callable and member ambiguity with semantic-token fixtures, and document
the provider-dependent refinement scope.
- Add a resource-scoped setting to disable semantic-token refinement, skip semantic
provider calls when it is off, and separate cached region trees by refinement
mode.
- Log semantic fallback paths for provider failures, missing legends, disabled
refinement, and skipped refinement while preserving structural folding behaviour.
- Add project workflow github action.

Refs #9
Refs #34
Refs #35
Refs #36