### PR TITLE
Advanced Filtering: Composite Multi-Filter & Preset System

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ Thumbs.db
 !.vscode/launch.json
 !.vscode/tasks.json
 !.vscode/extensions.json
+
+temp/

--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ These commands are available from the Command Palette and use the same filter pi
 | `semanticFold.toggleVariables` | Toggle variable, constant, and object regions that have foldable symbol ranges. |
 | `semanticFold.toggleFunctionsInVariables` | Toggle function and method regions anywhere inside a variable or object ancestor context, such as functions inside an object literal assigned to a variable. |
 | `semanticFold.toggleImports` | Toggle provider-exposed import folding ranges. |
+| `semanticFold.toggleReaderMode` | Toggle the Reader Mode preset that collapses imports, comments, regions, callable/member implementation blocks, and variable/object implementation detail while leaving top-level type structure visible. |
 
 Toggle methods whose immediate parent is a class:
 
@@ -278,6 +279,37 @@ The generic command equivalent is:
 }
 ```
 
+Toggle Reader Mode:
+
+```json
+{
+  "key": "ctrl+alt+shift+r",
+  "command": "semanticFold.toggleReaderMode"
+}
+```
+
+Reader Mode folds this category set:
+
+```json
+{
+  "filter": {
+    "kinds": [
+      "import",
+      "comment",
+      "region",
+      "constructor",
+      "method",
+      "function",
+      "property",
+      "field",
+      "variable",
+      "object"
+    ]
+  },
+  "mode": "toggle"
+}
+```
+
 Toggle comment blocks:
 
 ```json
@@ -366,6 +398,7 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Run `semanticFold.toggleVariables`; confirm foldable variable, constant, and object regions toggle.
 - Run `semanticFold.toggleFunctionsInVariables`; confirm function and method regions inside variable or object contexts toggle when the provider exposes that hierarchy.
 - Run `semanticFold.toggleImports`; confirm provider-exposed import folding ranges toggle together.
+- Run `semanticFold.toggleReaderMode`; confirm imports/comments/regions and implementation-heavy callable/member blocks collapse while top-level type declarations remain visible.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
 - Run `semanticFold.toggle` with the same filter; confirm it targets the same methods as collapse and expand.

--- a/README.md
+++ b/README.md
@@ -188,9 +188,12 @@ These commands are available from the Command Palette and use the same filter pi
 | `semanticFold.toggleVariables` | Toggle variable, constant, and object regions that have foldable symbol ranges. |
 | `semanticFold.toggleFunctionsInVariables` | Toggle function and method regions anywhere inside a variable or object ancestor context, such as functions inside an object literal assigned to a variable. |
 | `semanticFold.toggleImports` | Toggle provider-exposed import folding ranges. |
+| `semanticFold.toggleComments` | Toggle provider-exposed comment folding ranges. |
 | `semanticFold.toggleReaderMode` | Toggle the Reader Mode preset that collapses imports, comments, regions, callable/member implementation blocks, and variable/object implementation detail while leaving top-level type structure visible. |
 | `semanticFold.toggleApiOverview` | Toggle API Overview by collapsing structural noise plus nested variable/object containers while keeping callable/member signatures visible. |
 | `semanticFold.runComposite` | Run one collapse/expand/toggle request across a union of multiple filter queries supplied via `args.filters`. |
+
+For quick discovery in Command Palette, search `Semantic Fold` and pick the workflow you want.
 
 Toggle methods whose immediate parent is a class:
 
@@ -300,6 +303,29 @@ The generic command equivalent is:
 }
 ```
 
+Toggle comments:
+
+```json
+{
+  "key": "ctrl+alt+shift+c",
+  "command": "semanticFold.toggleComments"
+}
+```
+
+The generic command equivalent is:
+
+```json
+{
+  "key": "ctrl+alt+shift+c",
+  "command": "semanticFold.toggle",
+  "args": {
+    "filter": {
+      "kinds": ["comment"]
+    }
+  }
+}
+```
+
 Toggle Reader Mode:
 
 ```json
@@ -331,6 +357,66 @@ Reader Mode folds this category set:
 }
 ```
 
+The generic command equivalent is:
+
+```json
+{
+  "key": "ctrl+alt+shift+r",
+  "command": "semanticFold.toggle",
+  "args": {
+    "filter": {
+      "kinds": [
+        "import",
+        "comment",
+        "region",
+        "constructor",
+        "method",
+        "function",
+        "property",
+        "field",
+        "variable",
+        "object"
+      ]
+    },
+    "mode": "toggle"
+  }
+}
+```
+
+Top-level-only view via composite command:
+
+```json
+{
+  "key": "ctrl+alt+shift+t",
+  "command": "semanticFold.runComposite",
+  "args": {
+    "mode": "toggle",
+    "filters": [
+      {
+        "kinds": ["import", "comment", "region"]
+      },
+      {
+        "kinds": [
+          "class",
+          "struct",
+          "interface",
+          "enum",
+          "namespace",
+          "constructor",
+          "method",
+          "function",
+          "property",
+          "field",
+          "variable",
+          "object"
+        ],
+        "minSymbolDepth": 2
+      }
+    ]
+  }
+}
+```
+
 Toggle API Overview:
 
 ```json
@@ -354,6 +440,27 @@ API Overview combines these composite filters:
     }
   ],
   "mode": "toggle"
+}
+```
+
+The generic command equivalent is:
+
+```json
+{
+  "key": "ctrl+alt+shift+a",
+  "command": "semanticFold.runComposite",
+  "args": {
+    "mode": "toggle",
+    "filters": [
+      {
+        "kinds": ["import", "comment", "region"]
+      },
+      {
+        "kinds": ["variable", "object"],
+        "minSymbolDepth": 2
+      }
+    ]
+  }
 }
 ```
 
@@ -466,6 +573,7 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Run `semanticFold.toggleVariables`; confirm foldable variable, constant, and object regions toggle.
 - Run `semanticFold.toggleFunctionsInVariables`; confirm function and method regions inside variable or object contexts toggle when the provider exposes that hierarchy.
 - Run `semanticFold.toggleImports`; confirm provider-exposed import folding ranges toggle together.
+- Run `semanticFold.toggleComments`; confirm provider-exposed comment folding ranges toggle together.
 - Run `semanticFold.toggleReaderMode`; confirm imports/comments/regions and implementation-heavy callable/member blocks collapse while top-level type declarations remain visible.
 - Run `semanticFold.toggleApiOverview`; confirm it collapses imports/comments/regions and nested variable or object containers while methods/functions/properties/fields remain visible.
 - Run `semanticFold.runComposite` with two filters; confirm both filter queries contribute to one deduplicated target set.
@@ -662,11 +770,11 @@ Open the workspace in VS Code and launch the extension host from the debugger.
 - [x] Add filter engine
 - [x] Add targeted collapse execution
 - [x] Add keybinding-ready generic command
-- [ ] Add convenience commands
+- [x] Add convenience commands
 - [x] Add imports support
 - [x] Add comments/regions support
-- [ ] Add semantic-token refinement
-- [ ] Add presets
+- [x] Add semantic-token refinement
+- [x] Add presets
 - [ ] Publish extension
 
 ## Summary

--- a/README.md
+++ b/README.md
@@ -157,6 +157,25 @@ Toggle state is tracked for folds created through Semantic Fold commands. Manual
 
 Category support depends on the active language and folding providers. If the current editor does not report a category such as `import`, `comment`, or `region`, filters for that category simply produce no matching fold targets; other reported categories continue to work.
 
+`semanticFold.runComposite` accepts multiple filter objects and unions their fold targets into one command execution:
+
+```json
+{
+  "mode": "toggle",
+  "filters": [
+    {
+      "kinds": ["import", "comment", "region"]
+    },
+    {
+      "kinds": ["variable", "object"],
+      "minSymbolDepth": 2
+    }
+  ]
+}
+```
+
+Composite payloads use the same filter normalisation rules as single-filter commands. Invalid filter entries are dropped, and if no valid filters remain then the command is a no-op.
+
 ## Convenience commands
 
 These commands are available from the Command Palette and use the same filter pipeline as the generic commands:
@@ -170,6 +189,8 @@ These commands are available from the Command Palette and use the same filter pi
 | `semanticFold.toggleFunctionsInVariables` | Toggle function and method regions anywhere inside a variable or object ancestor context, such as functions inside an object literal assigned to a variable. |
 | `semanticFold.toggleImports` | Toggle provider-exposed import folding ranges. |
 | `semanticFold.toggleReaderMode` | Toggle the Reader Mode preset that collapses imports, comments, regions, callable/member implementation blocks, and variable/object implementation detail while leaving top-level type structure visible. |
+| `semanticFold.toggleApiOverview` | Toggle API Overview by collapsing structural noise plus nested variable/object containers while keeping callable/member signatures visible. |
+| `semanticFold.runComposite` | Run one collapse/expand/toggle request across a union of multiple filter queries supplied via `args.filters`. |
 
 Toggle methods whose immediate parent is a class:
 
@@ -310,6 +331,53 @@ Reader Mode folds this category set:
 }
 ```
 
+Toggle API Overview:
+
+```json
+{
+  "key": "ctrl+alt+shift+a",
+  "command": "semanticFold.toggleApiOverview"
+}
+```
+
+API Overview combines these composite filters:
+
+```json
+{
+  "filters": [
+    {
+      "kinds": ["import", "comment", "region"]
+    },
+    {
+      "kinds": ["variable", "object"],
+      "minSymbolDepth": 2
+    }
+  ],
+  "mode": "toggle"
+}
+```
+
+Run a custom composite keybinding:
+
+```json
+{
+  "key": "ctrl+alt+shift+u",
+  "command": "semanticFold.runComposite",
+  "args": {
+    "mode": "collapse",
+    "filters": [
+      {
+        "kinds": ["import", "comment"]
+      },
+      {
+        "kinds": ["method"],
+        "parentKinds": ["class"]
+      }
+    ]
+  }
+}
+```
+
 Toggle comment blocks:
 
 ```json
@@ -399,6 +467,8 @@ Use a file with a top-level class, methods inside that class, a nested function 
 - Run `semanticFold.toggleFunctionsInVariables`; confirm function and method regions inside variable or object contexts toggle when the provider exposes that hierarchy.
 - Run `semanticFold.toggleImports`; confirm provider-exposed import folding ranges toggle together.
 - Run `semanticFold.toggleReaderMode`; confirm imports/comments/regions and implementation-heavy callable/member blocks collapse while top-level type declarations remain visible.
+- Run `semanticFold.toggleApiOverview`; confirm it collapses imports/comments/regions and nested variable or object containers while methods/functions/properties/fields remain visible.
+- Run `semanticFold.runComposite` with two filters; confirm both filter queries contribute to one deduplicated target set.
 - Add `"mode": "collapse"` to the same keybinding; confirm repeated use stays a one-way collapse request.
 - Run `semanticFold.expand` with the same filter; confirm only the matching methods expand.
 - Run `semanticFold.toggle` with the same filter; confirm it targets the same methods as collapse and expand.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "semantic-fold",
-  "version": "0.1.3",
+  "version": "0.1.4-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "semantic-fold",
-      "version": "0.1.3",
+      "version": "0.1.4-dev",
       "devDependencies": {
         "@types/mocha": "^10.0.10",
         "@types/node": "22.x",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,10 @@
         "title": "Semantic Fold: Toggle"
       },
       {
+        "command": "semanticFold.runComposite",
+        "title": "Semantic Fold: Run Composite"
+      },
+      {
         "command": "semanticFold.inspectRegions",
         "title": "Semantic Fold: Inspect Regions"
       },
@@ -59,6 +63,10 @@
       {
         "command": "semanticFold.toggleReaderMode",
         "title": "Semantic Fold: Toggle Reader Mode"
+      },
+      {
+        "command": "semanticFold.toggleApiOverview",
+        "title": "Semantic Fold: Toggle API Overview"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "semantic-fold",
   "displayName": "Semantic Fold",
   "description": "Policy-driven code folding for VS Code",
-  "version": "0.1.3",
+  "version": "0.1.4-dev",
   "engines": {
     "vscode": "^1.111.0"
   },
@@ -55,6 +55,10 @@
       {
         "command": "semanticFold.toggleImports",
         "title": "Semantic Fold: Toggle Imports"
+      },
+      {
+        "command": "semanticFold.toggleReaderMode",
+        "title": "Semantic Fold: Toggle Reader Mode"
       }
     ],
     "configuration": {

--- a/package.json
+++ b/package.json
@@ -61,6 +61,10 @@
         "title": "Semantic Fold: Toggle Imports"
       },
       {
+        "command": "semanticFold.toggleComments",
+        "title": "Semantic Fold: Toggle Comments"
+      },
+      {
         "command": "semanticFold.toggleReaderMode",
         "title": "Semantic Fold: Toggle Reader Mode"
       },

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -1,6 +1,11 @@
 import { type CollapseArgs } from "../model/filters";
 import { runCompositeFoldCommand, runFoldCommand } from "./foldCommand";
-import { apiOverviewFilters, readerModeArgs } from "./presets";
+import {
+	apiOverviewFilters,
+	commentsArgs,
+	importsArgs,
+	readerModeArgs,
+} from "./presets";
 
 /*
  * Filters for contributed commands, provider-backed categories only
@@ -44,13 +49,6 @@ const functionsInVariablesArgs: CollapseArgs = {
 	mode: "toggle",
 };
 
-const importsArgs: CollapseArgs = {
-	filter: {
-		kinds: ["import"],
-	},
-	mode: "toggle",
-};
-
 /**
  * Base collapse command used by the command palette and keybinding payloads
  */
@@ -60,6 +58,10 @@ export async function collapseCommand(args?: unknown): Promise<void> {
 
 export async function toggleReaderModeCommand(): Promise<void> {
 	await collapseCommand(readerModeArgs);
+}
+
+export async function toggleCommentsCommand(): Promise<void> {
+	await collapseCommand(commentsArgs);
 }
 
 export async function toggleApiOverviewCommand(): Promise<void> {

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -1,27 +1,10 @@
 import { type CollapseArgs } from "../model/filters";
-import { runFoldCommand } from "./foldCommand";
+import { runCompositeFoldCommand, runFoldCommand } from "./foldCommand";
+import { apiOverviewFilters, readerModeArgs } from "./presets";
 
 /*
  * Filters for contributed commands, provider-backed categories only
  */
-
-const readerModeArgs: CollapseArgs = {
-	filter: {
-		kinds: [
-			"import",
-			"comment",
-			"region",
-			"constructor",
-			"method",
-			"function",
-			"property",
-			"field",
-			"variable",
-			"object",
-		],
-	},
-	mode: "toggle",
-};
 
 const methodsInClassesArgs: CollapseArgs = {
 	filter: {
@@ -77,6 +60,13 @@ export async function collapseCommand(args?: unknown): Promise<void> {
 
 export async function toggleReaderModeCommand(): Promise<void> {
 	await collapseCommand(readerModeArgs);
+}
+
+export async function toggleApiOverviewCommand(): Promise<void> {
+	await runCompositeFoldCommand({
+		filters: apiOverviewFilters,
+		mode: "toggle",
+	}, "toggle");
 }
 
 export async function toggleMethodsInClassesCommand(): Promise<void> {

--- a/src/commands/collapse.ts
+++ b/src/commands/collapse.ts
@@ -5,6 +5,24 @@ import { runFoldCommand } from "./foldCommand";
  * Filters for contributed commands, provider-backed categories only
  */
 
+const readerModeArgs: CollapseArgs = {
+	filter: {
+		kinds: [
+			"import",
+			"comment",
+			"region",
+			"constructor",
+			"method",
+			"function",
+			"property",
+			"field",
+			"variable",
+			"object",
+		],
+	},
+	mode: "toggle",
+};
+
 const methodsInClassesArgs: CollapseArgs = {
 	filter: {
 		kinds: ["method", "function"],
@@ -55,6 +73,10 @@ const importsArgs: CollapseArgs = {
  */
 export async function collapseCommand(args?: unknown): Promise<void> {
 	await runFoldCommand(args, getDefaultCollapseMode(args));
+}
+
+export async function toggleReaderModeCommand(): Promise<void> {
+	await collapseCommand(readerModeArgs);
 }
 
 export async function toggleMethodsInClassesCommand(): Promise<void> {

--- a/src/commands/composite.ts
+++ b/src/commands/composite.ts
@@ -1,0 +1,8 @@
+import { runCompositeFoldCommand } from "./foldCommand";
+
+/**
+ * Command-palette entry point for composite multi-filter folding
+ */
+export async function runCompositeCommand(args?: unknown): Promise<void> {
+	await runCompositeFoldCommand(args, "toggle");
+}

--- a/src/commands/foldCommand.ts
+++ b/src/commands/foldCommand.ts
@@ -1,7 +1,12 @@
 import * as vscode from "vscode";
 import { getRegions } from "../engine/regionCollector";
-import { execFoldCommand } from "../engine/foldExecutor";
-import { type CollapseArgs, normaliseArgs } from "../model/filters";
+import { execCompositeFoldCommand, execFoldCommand } from "../engine/foldExecutor";
+import {
+	type CollapseArgs,
+	type CompositeCollapseArgs,
+	normaliseArgs,
+	normaliseCompositeArgs,
+} from "../model/filters";
 
 /**
  * Shared command runner for collapse, expand, toggle, and convenience commands
@@ -18,4 +23,22 @@ export async function runFoldCommand(args: unknown, defaultMode: CollapseArgs["m
 	
 	const regions = await getRegions(editor.document);
 	await execFoldCommand(normaliseArgs(args, defaultMode), regions);
+}
+
+/**
+ * Shared command runner for multi-filter composite fold execution
+ */
+export async function runCompositeFoldCommand(
+	args: unknown,
+	defaultMode: CompositeCollapseArgs["mode"] = "toggle"
+): Promise<void> {
+	const editor = vscode.window.activeTextEditor;
+
+	if(!editor) {
+		return;
+	}
+
+	const regions = await getRegions(editor.document);
+
+	await execCompositeFoldCommand(normaliseCompositeArgs(args, defaultMode), regions);
 }

--- a/src/commands/presets.ts
+++ b/src/commands/presets.ts
@@ -5,13 +5,13 @@ import { type RegionKind } from "../model/region";
  * Reusable filter groups used by overview-style preset commands
  */
 
-const structuralNoiseKinds: readonly RegionKind[] = [
+export const structuralNoiseKinds: readonly RegionKind[] = [
 	"import",
 	"comment",
 	"region",
 ];
 
-const callableAndMemberKinds: readonly RegionKind[] = [
+export const callableAndMemberKinds: readonly RegionKind[] = [
 	"constructor",
 	"method",
 	"function",
@@ -19,7 +19,7 @@ const callableAndMemberKinds: readonly RegionKind[] = [
 	"field",
 ];
 
-const implementationContainerKinds: readonly RegionKind[] = [
+export const implementationContainerKinds: readonly RegionKind[] = [
 	"variable",
 	"object",
 ];
@@ -46,12 +46,14 @@ const overviewKinds = composeKinds(
 );
 
 export const readerModeArgs: CollapseArgs = createTogglePreset(overviewKinds);
+export const importsArgs: CollapseArgs = createTogglePreset(["import"]);
+export const commentsArgs: CollapseArgs = createTogglePreset(["comment"]);
 export const apiOverviewFilters: CollapseFilter[] = [
 	{
-		kinds: ["import", "comment", "region"],
+		kinds: [...structuralNoiseKinds],
 	},
 	{
-		kinds: ["variable", "object"],
-		exactSymbolDepth: 2,
+		kinds: [...implementationContainerKinds],
+		minSymbolDepth: 2,
 	},
 ];

--- a/src/commands/presets.ts
+++ b/src/commands/presets.ts
@@ -1,0 +1,57 @@
+import { type CollapseArgs, type CollapseFilter } from "../model/filters";
+import { type RegionKind } from "../model/region";
+
+/*
+ * Reusable filter groups used by overview-style preset commands
+ */
+
+const structuralNoiseKinds: readonly RegionKind[] = [
+	"import",
+	"comment",
+	"region",
+];
+
+const callableAndMemberKinds: readonly RegionKind[] = [
+	"constructor",
+	"method",
+	"function",
+	"property",
+	"field",
+];
+
+const implementationContainerKinds: readonly RegionKind[] = [
+	"variable",
+	"object",
+];
+
+function composeKinds(
+	...kindGroups: readonly (readonly RegionKind[])[]
+): RegionKind[] {
+	return [...new Set(kindGroups.flat())];
+}
+
+function createTogglePreset(kinds: readonly RegionKind[]): CollapseArgs {
+	return {
+		filter: {
+			kinds: [...kinds],
+		},
+		mode: "toggle",
+	};
+}
+
+const overviewKinds = composeKinds(
+	structuralNoiseKinds,
+	callableAndMemberKinds,
+	implementationContainerKinds
+);
+
+export const readerModeArgs: CollapseArgs = createTogglePreset(overviewKinds);
+export const apiOverviewFilters: CollapseFilter[] = [
+	{
+		kinds: ["import", "comment", "region"],
+	},
+	{
+		kinds: ["variable", "object"],
+		exactSymbolDepth: 2,
+	},
+];

--- a/src/engine/foldExecutor.ts
+++ b/src/engine/foldExecutor.ts
@@ -1,5 +1,5 @@
 import * as vscode from "vscode";
-import type { CollapseArgs } from "../model/filters";
+import type { CollapseArgs, CollapseFilter, CompositeCollapseArgs } from "../model/filters";
 import type { RegionNode } from "../model/region";
 import { filterRegions } from "./filterEngine";
 
@@ -134,6 +134,32 @@ export function selectFoldableRegions(
 }
 
 /**
+ * Applies each filter independently then unions targets by selection line
+ */
+export function selectFoldableRegionsForFilters(
+	filters: readonly CollapseFilter[],
+	rootNodes: readonly RegionNode[]
+): RegionNode[] {
+	const selectedRegionsByLine = new Map<number, RegionNode>();
+
+	for(const filter of filters) {
+		const regions = selectFoldableRegions({ filter }, rootNodes);
+
+		for(const region of regions) {
+			if(selectedRegionsByLine.has(region.selectionLine)) {
+				continue;
+			}
+
+			selectedRegionsByLine.set(region.selectionLine, region);
+		}
+	}
+
+	return [...selectedRegionsByLine.values()].sort((left, right) => {
+		return left.selectionLine - right.selectionLine;
+	});
+}
+
+/**
  * Converts selected regions into the exact start lines sent to VS Code
  *
  * The Set removes duplicated targets from overlapping symbol and folding-range
@@ -170,6 +196,35 @@ export async function execFoldCommand(
 }
 
 /**
+ * Executes a fold request using the union of multiple structural filters
+ */
+export async function execCompositeFoldCommand(
+	args: CompositeCollapseArgs,
+	rootNodes: readonly RegionNode[] = [],
+	executeCommand: FoldCommandExecutor = defaultFoldCommandExecutor,
+	foldState: TrackedFoldState = defaultFoldState,
+	documentKey: string = getActiveDocumentKey()
+): Promise<void> {
+	if(!args.filters || args.filters.length === 0) {
+		return;
+	}
+
+	const selectionLines = collectSelectionLines(
+		selectFoldableRegionsForFilters(args.filters, rootNodes)
+	);
+
+	if(selectionLines.length === 0) {
+		return;
+	}
+
+	const command = getFoldCommand(args, selectionLines, foldState, documentKey);
+
+	// levels: 1 keeps Semantic Fold targeted instead of recursively folding children
+	await executeCommand(command, { selectionLines, levels: 1 });
+	updateTrackedFoldState(command, selectionLines, foldState, documentKey);
+}
+
+/**
  * Recursive helper for collecting foldable nodes without flattening the tree first
  */
 function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]): void {
@@ -186,7 +241,7 @@ function collectFoldableRegion(region: RegionNode, foldableRegions: RegionNode[]
  * Resolves the VS Code command to execute for the requested fold mode
  */
 function getFoldCommand(
-	args: CollapseArgs,
+	args: Pick<CollapseArgs, "mode">,
 	selectionLines: readonly number[],
 	foldState: TrackedFoldState,
 	documentKey: string

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode";
 import {
 	collapseCommand,
+	toggleApiOverviewCommand,
 	toggleClassMembersCommand,
 	toggleFunctionsInVariablesCommand,
 	toggleImportsCommand,
@@ -9,6 +10,7 @@ import {
 	toggleTypesCommand,
 	toggleVariablesCommand,
 } from "./commands/collapse";
+import { runCompositeCommand } from "./commands/composite";
 import { expandCommand } from "./commands/expand";
 import { inspectRegionsCommand } from "./commands/inspectRegions";
 import { toggleCommand } from "./commands/toggle";
@@ -65,6 +67,14 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand(
 			"semanticFold.toggleReaderMode",
 			toggleReaderModeCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleApiOverview",
+			toggleApiOverviewCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.runComposite",
+			runCompositeCommand
 		),
 		// Text changes use debounce because providers can be expensive
 		vscode.workspace.onDidChangeTextDocument((event) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,6 +3,7 @@ import {
 	collapseCommand,
 	toggleApiOverviewCommand,
 	toggleClassMembersCommand,
+	toggleCommentsCommand,
 	toggleFunctionsInVariablesCommand,
 	toggleImportsCommand,
 	toggleMethodsInClassesCommand,
@@ -63,6 +64,10 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand(
 			"semanticFold.toggleImports",
 			toggleImportsCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleComments",
+			toggleCommentsCommand
 		),
 		vscode.commands.registerCommand(
 			"semanticFold.toggleReaderMode",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import {
 	toggleFunctionsInVariablesCommand,
 	toggleImportsCommand,
 	toggleMethodsInClassesCommand,
+	toggleReaderModeCommand,
 	toggleTypesCommand,
 	toggleVariablesCommand,
 } from "./commands/collapse";
@@ -60,6 +61,10 @@ export function activate(context: vscode.ExtensionContext): void {
 		vscode.commands.registerCommand(
 			"semanticFold.toggleImports",
 			toggleImportsCommand
+		),
+		vscode.commands.registerCommand(
+			"semanticFold.toggleReaderMode",
+			toggleReaderModeCommand
 		),
 		// Text changes use debounce because providers can be expensive
 		vscode.workspace.onDidChangeTextDocument((event) => {

--- a/src/model/filters.ts
+++ b/src/model/filters.ts
@@ -80,6 +80,26 @@ export interface CollapseArgs {
 	preserveCursorContext?: boolean;
 }
 
+/**
+ * Command arguments for multi-filter fold execution
+ */
+export interface CompositeCollapseArgs {
+	/**
+	 * Structural filters applied independently then unioned
+	 */
+	filters?: CollapseFilter[];
+
+	/**
+	 * Requested fold behaviour
+	 */
+	mode?: "collapse" | "expand" | "toggle";
+
+	/**
+	 * Option for future cursor-aware command behaviour
+	 */
+	preserveCursorContext?: boolean;
+}
+
 type DepthFilterKey =
 	| "exactSymbolDepth"
 	| "minSymbolDepth"
@@ -119,6 +139,28 @@ export function normaliseArgs(args: unknown, mode: CollapseArgs["mode"] = "colla
 
 	if(filter !== undefined) {
 		normalisedArgs.filter = filter;
+	}
+
+	if(typeof payload.preserveCursorContext === "boolean") {
+		normalisedArgs.preserveCursorContext = payload.preserveCursorContext;
+	}
+
+	return normalisedArgs;
+}
+
+/**
+ * Converts arbitrary payloads into the safe internal multi-filter command shape
+ */
+export function normaliseCompositeArgs(
+	args: unknown,
+	mode: CompositeCollapseArgs["mode"] = "toggle"
+): CompositeCollapseArgs {
+	const payload = isRecord(args) ? args : {};
+	const normalisedArgs: CompositeCollapseArgs = { mode: normaliseMode(payload.mode) ?? mode };
+	const filters = normaliseCollapseFilters(payload.filters);
+
+	if(filters.length > 0) {
+		normalisedArgs.filters = filters;
 	}
 
 	if(typeof payload.preserveCursorContext === "boolean") {
@@ -174,6 +216,21 @@ export function normaliseCollapseFilter(filter: unknown): CollapseFilter | undef
 	}
 
 	return normalisedFilter;
+}
+
+/**
+ * Sanitises an array of filter objects while dropping invalid entries
+ */
+export function normaliseCollapseFilters(filters: unknown): CollapseFilter[] {
+	if(!Array.isArray(filters)) {
+		return [];
+	}
+
+	return filters.map((filter) => {
+		return normaliseCollapseFilter(filter);
+	}).filter((filter): filter is CollapseFilter => {
+		return filter !== undefined;
+	});
 }
 
 /**

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,7 +1,11 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDefaultCollapseMode } from "../commands/collapse";
-import { apiOverviewFilters, readerModeArgs } from "../commands/presets";
+import {
+	apiOverviewFilters,
+	commentsArgs,
+	readerModeArgs,
+} from "../commands/presets";
 import { filterRegions, flattenRegions, getAncestors, hasHierarchy } from "../engine/filterEngine";
 import { attachFoldingOnlyNodes, normaliseFoldingRanges } from "../engine/foldingRangeRefiner";
 import {
@@ -53,6 +57,7 @@ suite("Semantic Fold Foundation", () => {
 		assert.ok(commands.includes("semanticFold.toggleVariables"));
 		assert.ok(commands.includes("semanticFold.toggleFunctionsInVariables"));
 		assert.ok(commands.includes("semanticFold.toggleImports"));
+		assert.ok(commands.includes("semanticFold.toggleComments"));
 		assert.ok(commands.includes("semanticFold.toggleReaderMode"));
 		assert.ok(commands.includes("semanticFold.toggleApiOverview"));
 	});
@@ -64,6 +69,34 @@ suite("Semantic Fold Foundation", () => {
 		assert.strictEqual(setting.type, "boolean");
 		assert.strictEqual(setting.default, true);
 		assert.strictEqual(setting.scope, "resource");
+	});
+
+	test("uses a consistent command-palette naming pattern for flagship presets", () => {
+		const extension = getSemanticFoldExtension();
+		const commands = extension.packageJSON.contributes.commands as Array<{
+			command: string;
+			title: string;
+		}>;
+		const commandTitleById = new Map(commands.map((entry) => {
+			return [entry.command, entry.title] as const;
+		}));
+
+		assert.strictEqual(
+			commandTitleById.get("semanticFold.toggleImports"),
+			"Semantic Fold: Toggle Imports"
+		);
+		assert.strictEqual(
+			commandTitleById.get("semanticFold.toggleComments"),
+			"Semantic Fold: Toggle Comments"
+		);
+		assert.strictEqual(
+			commandTitleById.get("semanticFold.toggleReaderMode"),
+			"Semantic Fold: Toggle Reader Mode"
+		);
+		assert.strictEqual(
+			commandTitleById.get("semanticFold.toggleApiOverview"),
+			"Semantic Fold: Toggle API Overview"
+		);
 	});
 });
 
@@ -1684,6 +1717,15 @@ suite("Region Filtering", () => {
 		);
 	});
 
+	test("applies comments preset categories across symbol and folding ranges", () => {
+		const regions = createMixedSymbolAndFoldingFixture();
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions(commentsArgs, regions)),
+			[12, 22]
+		);
+	});
+
 	test("applies API overview preset categories across symbol and folding ranges", () => {
 		const regions = createMixedSymbolAndFoldingFixture();
 
@@ -1699,6 +1741,19 @@ suite("Region Filtering", () => {
 		assert.deepStrictEqual(
 			collectSelectionLines(selectFoldableRegionsForFilters(apiOverviewFilters, regions)),
 			[0, 12, 20, 22, 28]
+		);
+	});
+
+	test("fails soft when preset categories are absent for the active provider", () => {
+		const regions = createPhaseOneFixture();
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions(commentsArgs, regions)),
+			[]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegionsForFilters(apiOverviewFilters, regions)),
+			[]
 		);
 	});
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -44,6 +44,7 @@ suite("Semantic Fold Foundation", () => {
 		assert.ok(commands.includes("semanticFold.toggleVariables"));
 		assert.ok(commands.includes("semanticFold.toggleFunctionsInVariables"));
 		assert.ok(commands.includes("semanticFold.toggleImports"));
+		assert.ok(commands.includes("semanticFold.toggleReaderMode"));
 	});
 
 	test("contributes semantic refinement configuration", () => {
@@ -1598,6 +1599,49 @@ suite("Region Filtering", () => {
 				},
 			}, regions)),
 			[72, 78, 88]
+		);
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: [
+						"import",
+						"comment",
+						"region",
+						"constructor",
+						"method",
+						"function",
+						"property",
+						"field",
+						"variable",
+						"object",
+					],
+				},
+			}, regions)),
+			[1, 5, 7, 21, 32, 70, 72, 78, 86, 88]
+		);
+	});
+
+	test("applies reader mode preset categories across symbol and folding ranges", () => {
+		const regions = createMixedSymbolAndFoldingFixture();
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegions({
+				filter: {
+					kinds: [
+						"import",
+						"comment",
+						"region",
+						"constructor",
+						"method",
+						"function",
+						"property",
+						"field",
+						"variable",
+						"object",
+					],
+				},
+			}, regions)),
+			[0, 5, 10, 12, 14, 20, 22, 40]
 		);
 	});
 

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -1,12 +1,15 @@
 import * as assert from "assert";
 import * as vscode from "vscode";
 import { getDefaultCollapseMode } from "../commands/collapse";
+import { apiOverviewFilters, readerModeArgs } from "../commands/presets";
 import { filterRegions, flattenRegions, getAncestors, hasHierarchy } from "../engine/filterEngine";
 import { attachFoldingOnlyNodes, normaliseFoldingRanges } from "../engine/foldingRangeRefiner";
 import {
 	collectFoldableRegions,
 	collectSelectionLines,
+	execCompositeFoldCommand,
 	execFoldCommand,
+	selectFoldableRegionsForFilters,
 	selectFoldableRegions,
 	TrackedFoldState,
 } from "../engine/foldExecutor";
@@ -18,7 +21,12 @@ import { formatRegionDiagnostics } from "../engine/regionDiagnostics";
 import { getRegions } from "../engine/regionCollector";
 import { refineWithSemanticTokens } from "../engine/semanticRefiner";
 import { normalizeSymbols } from "../engine/symbolNormaliser";
-import { type CollapseFilter, normaliseArgs, normaliseCollapseFilter } from "../model/filters";
+import {
+	type CollapseFilter,
+	normaliseArgs,
+	normaliseCollapseFilter,
+	normaliseCompositeArgs,
+} from "../model/filters";
 import {
 	clearRegionCache,
 	getCachedRegions,
@@ -37,6 +45,7 @@ suite("Semantic Fold Foundation", () => {
 		assert.ok(commands.includes("semanticFold.collapse"));
 		assert.ok(commands.includes("semanticFold.expand"));
 		assert.ok(commands.includes("semanticFold.toggle"));
+		assert.ok(commands.includes("semanticFold.runComposite"));
 		assert.ok(commands.includes("semanticFold.inspectRegions"));
 		assert.ok(commands.includes("semanticFold.toggleMethodsInClasses"));
 		assert.ok(commands.includes("semanticFold.toggleClassMembers"));
@@ -45,6 +54,7 @@ suite("Semantic Fold Foundation", () => {
 		assert.ok(commands.includes("semanticFold.toggleFunctionsInVariables"));
 		assert.ok(commands.includes("semanticFold.toggleImports"));
 		assert.ok(commands.includes("semanticFold.toggleReaderMode"));
+		assert.ok(commands.includes("semanticFold.toggleApiOverview"));
 	});
 
 	test("contributes semantic refinement configuration", () => {
@@ -1149,6 +1159,50 @@ suite("Command Argument Normalisation", () => {
 		});
 	});
 
+	test("normalises composite command payloads and drops invalid filters", () => {
+		assert.deepStrictEqual(
+			normaliseCompositeArgs({
+				mode: "collapse",
+				filters: [
+					{
+						kinds: ["method", "function"],
+						parentKinds: ["class"],
+					},
+					{
+						kinds: "method",
+					},
+					{
+						minSymbolDepth: 2,
+					},
+					"bad",
+				],
+				preserveCursorContext: true,
+			}),
+			{
+				mode: "collapse",
+				filters: [
+					{
+						kinds: ["method", "function"],
+						parentKinds: ["class"],
+					},
+					{
+						minSymbolDepth: 2,
+					},
+				],
+				preserveCursorContext: true,
+			}
+		);
+		assert.deepStrictEqual(normaliseCompositeArgs(undefined), {
+			mode: "toggle",
+		});
+		assert.deepStrictEqual(normaliseCompositeArgs({
+			mode: "expand",
+			filters: [{ kinds: "bad" }],
+		}), {
+			mode: "expand",
+		});
+	});
+
 	test("defaults collapse keybinding payloads to toggle mode", () => {
 		assert.strictEqual(getDefaultCollapseMode(undefined), "collapse");
 		assert.strictEqual(getDefaultCollapseMode({}), "toggle");
@@ -1625,23 +1679,26 @@ suite("Region Filtering", () => {
 		const regions = createMixedSymbolAndFoldingFixture();
 
 		assert.deepStrictEqual(
-			collectSelectionLines(selectFoldableRegions({
-				filter: {
-					kinds: [
-						"import",
-						"comment",
-						"region",
-						"constructor",
-						"method",
-						"function",
-						"property",
-						"field",
-						"variable",
-						"object",
-					],
-				},
-			}, regions)),
+			collectSelectionLines(selectFoldableRegions(readerModeArgs, regions)),
 			[0, 5, 10, 12, 14, 20, 22, 40]
+		);
+	});
+
+	test("applies API overview preset categories across symbol and folding ranges", () => {
+		const regions = createMixedSymbolAndFoldingFixture();
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegionsForFilters(apiOverviewFilters, regions)),
+			[0, 12, 20, 22]
+		);
+	});
+
+	test("keeps callable and top-level containers visible in API overview", () => {
+		const regions = createApiOverviewFixture();
+
+		assert.deepStrictEqual(
+			collectSelectionLines(selectFoldableRegionsForFilters(apiOverviewFilters, regions)),
+			[0, 12, 20, 22, 28]
 		);
 	});
 
@@ -2381,6 +2438,165 @@ suite("Fold Execution Guards", () => {
 		})));
 	});
 
+	test("unions composite filter targets with deduplicated sorted lines", async () => {
+		const regions = createConvenienceCommandFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		await execCompositeFoldCommand({
+			mode: "collapse",
+			filters: [
+				{
+					kinds: ["method"],
+					parentKinds: ["class"],
+				},
+				{
+					kinds: ["constructor", "method", "property", "field"],
+					parentKinds: ["class"],
+				},
+			],
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://composite-union");
+
+		assert.deepStrictEqual(executedCommands, [{
+			command: "editor.fold",
+			levels: 1,
+			selectionLines: [1, 5, 21],
+		}]);
+	});
+
+	test("uses the requested mode for composite fold execution", async () => {
+		const regions = createConvenienceCommandFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+		const modeCases = [
+			{
+				documentKey: "test://composite-collapse",
+				expectedCommand: "editor.fold" as const,
+				mode: "collapse" as const,
+			},
+			{
+				documentKey: "test://composite-expand",
+				expectedCommand: "editor.unfold" as const,
+				mode: "expand" as const,
+			},
+			{
+				documentKey: "test://composite-toggle",
+				expectedCommand: "editor.fold" as const,
+				mode: "toggle" as const,
+			},
+		];
+
+		for(const modeCase of modeCases) {
+			await execCompositeFoldCommand({
+				mode: modeCase.mode,
+				filters: [{
+					kinds: ["constructor", "method", "property", "field"],
+					parentKinds: ["class"],
+				}],
+			}, regions, async (command, args) => {
+				executedCommands.push({
+					command,
+					levels: args.levels,
+					selectionLines: args.selectionLines,
+				});
+			}, foldState, modeCase.documentKey);
+		}
+
+		assert.deepStrictEqual(executedCommands, modeCases.map((modeCase) => ({
+			command: modeCase.expectedCommand,
+			levels: 1,
+			selectionLines: [1, 5, 21],
+		})));
+	});
+
+	test("toggles composite targets as one union set", async () => {
+		const regions = createConvenienceCommandFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+		const filters: CollapseFilter[] = [
+			{
+				kinds: ["method"],
+				parentKinds: ["class"],
+			},
+			{
+				kinds: ["constructor", "method", "property", "field"],
+				parentKinds: ["class"],
+			},
+		];
+
+		await execCompositeFoldCommand({
+			mode: "toggle",
+			filters,
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://composite-toggle-union");
+
+		await execCompositeFoldCommand({
+			mode: "toggle",
+			filters,
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://composite-toggle-union");
+
+		assert.deepStrictEqual(executedCommands, [
+			{
+				command: "editor.fold",
+				levels: 1,
+				selectionLines: [1, 5, 21],
+			},
+			{
+				command: "editor.unfold",
+				levels: 1,
+				selectionLines: [1, 5, 21],
+			},
+		]);
+	});
+
+	test("does not execute composite commands when filters are absent or no-op", async () => {
+		const regions = createPhaseOneFixture();
+		const executedCommands: ExecutedCommand[] = [];
+		const foldState = new TrackedFoldState();
+
+		await execCompositeFoldCommand({
+			mode: "toggle",
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://composite-empty");
+
+		await execCompositeFoldCommand({
+			mode: "toggle",
+			filters: [{
+				kinds: ["import"],
+			}],
+		}, regions, async (command, args) => {
+			executedCommands.push({
+				command,
+				levels: args.levels,
+				selectionLines: args.selectionLines,
+			});
+		}, foldState, "test://composite-no-match");
+
+		assert.deepStrictEqual(executedCommands, []);
+	});
+
 	test("handles no-match filters cleanly for every fold mode", async () => {
 		const regions = createPhaseOneFixture();
 		const executedCommands: ExecutedCommand[] = [];
@@ -2577,6 +2793,25 @@ function createMixedSymbolAndFoldingFixture(): ReturnType<typeof attachFoldingOn
 		new vscode.FoldingRange(12, 13, vscode.FoldingRangeKind.Comment),
 		new vscode.FoldingRange(22, 23, vscode.FoldingRangeKind.Comment),
 		new vscode.FoldingRange(20, 26, vscode.FoldingRangeKind.Region),
+	]);
+}
+
+function createApiOverviewFixture(): ReturnType<typeof attachFoldingOnlyNodes> {
+	const topLevelObjectSymbol = createSymbol("registry", vscode.SymbolKind.Object, 2, 40);
+	const nestedObjectSymbol = createSymbol("routes", vscode.SymbolKind.Object, 12, 24);
+	const nestedVariableSymbol = createSymbol("cache", vscode.SymbolKind.Variable, 28, 34);
+	const methodSymbol = createSymbol("bootstrap", vscode.SymbolKind.Method, 36, 38);
+	const topLevelVariableSymbol = createSymbol("settings", vscode.SymbolKind.Variable, 42, 52);
+
+	topLevelObjectSymbol.children.push(nestedObjectSymbol, nestedVariableSymbol, methodSymbol);
+
+	return attachFoldingOnlyNodes(normalizeSymbols([
+		topLevelObjectSymbol,
+		topLevelVariableSymbol,
+	]), [
+		new vscode.FoldingRange(0, 1, vscode.FoldingRangeKind.Imports),
+		new vscode.FoldingRange(20, 23, vscode.FoldingRangeKind.Comment),
+		new vscode.FoldingRange(22, 26, vscode.FoldingRangeKind.Region),
 	]);
 }
 


### PR DESCRIPTION
### Summary
This PR introduces composite filter execution with multi-filter support, modular preset architecture with noise-reduction presets, and enhanced API overview capabilities for better structural code analysis.

### Key Features

**Composite Multi-Filter System**
- New `semanticFold.runComposite` command accepting `filters[]` payload
- Unions multiple filter queries into one deduplicated fold target set
- Advanced filtering workflows for complex code navigation
- Preserves callable/member signatures while collapsing structural noise

**Modular Preset Architecture**
- Refactored preset kinds into reusable modular groups
- Aligned flagship preset naming for clear Command Palette discovery
- Focused noise-reduction preset coverage with dedicated imports and comments workflows
- Soft no-match behavior for unsupported provider categories

**API Overview Enhancement**
- Updated docs with composite filter usage patterns
- Preset-based folding for structural noise reduction and nested container management

### Changes
- ✨ feat(commands): add composite multi-filter folding
- ✨ feat(filters): composite filters and presets
- 📝 docs: expand composite filter and preset documentation
- 🧪 test: add composite execution, deduping, and preset discoverability coverage
- 🔧 fix: project flow github action
- 🔧 chore: merge updated action and phase updates

### Issues
Closes #11, #39, #40, #41, #42

### Testing
- Added regression coverage for normalization and composite execution modes
- Added dedup verification for composite filters
- Added tests for API Overview behavior with presets
- Added preset discoverability and usage tests

### Breaking Changes
None